### PR TITLE
Update Build-Windows.yml

### DIFF
--- a/.github/workflows/Build-Windows.yml
+++ b/.github/workflows/Build-Windows.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python3 -m pip install --upgrade pip3
 
 
       # Build python script into a stand-alone exe


### PR DESCRIPTION
Fix a typo in the auto build which would try to install pip3 where due to GitHub actions pip is the only package