### PR TITLE
Extract injector body to main function, to allow importing

### DIFF
--- a/injector/steamodded_injector.py
+++ b/injector/steamodded_injector.py
@@ -25,7 +25,7 @@ def merge_directory_contents(directory_path):
     directory_content = ""
     if os.path.exists(directory_path):
         print(f"Processing directory: {directory_path}")
-        for file_name in os.listdir(directory_path):
+        for file_name in sorted(os.listdir(directory_path)):
             if file_name.endswith(".lua"):
                 file_path = os.path.join(directory_path, file_name)
                 try:

--- a/injector/steamodded_injector.py
+++ b/injector/steamodded_injector.py
@@ -1,11 +1,11 @@
-import subprocess
 import os
+import platform
+import subprocess
 import sys
 import tempfile
 import zipfile
-import shutil
-import platform
 import requests
+
 
 def download_file(url, output_path):
     response = requests.get(url, stream=True)
@@ -35,8 +35,10 @@ def merge_directory_contents(directory_path):
                         print(f"Appended {file_name} to the directory content")
                 except IOError as e:
                     print(f"Error reading {file_path}: {e}")
+                    raise RuntimeError()
     else:
         print(f"Directory not found: {directory_path}")
+        raise RuntimeError()
     return directory_content
 
 
@@ -48,7 +50,11 @@ def modify_main_lua(main_lua_path, base_dir, directories):
             main_lua_content = file.read()
     except IOError as e:
         print(f"Error reading {main_lua_path}: {e}")
-        return
+        raise RuntimeError()
+
+    if "----MOD CORE----" in main_lua_content:
+        print(f"Mod loader already present in {main_lua_path}, aborting")
+        raise RuntimeError()
 
     for directory in directories:
         directory_path = os.path.join(base_dir, directory)
@@ -61,6 +67,7 @@ def modify_main_lua(main_lua_path, base_dir, directories):
             file.write(main_lua_content)
     except IOError as e:
         print(f"Error writing to {main_lua_path}: {e}")
+        raise RuntimeError()
 
 
 def modify_game_lua(game_lua_path):
@@ -85,127 +92,145 @@ def modify_game_lua(game_lua_path):
             print("Successfully modified game.lua.")
         else:
             print("Target line not found in game.lua.")
+            raise RuntimeError()
 
     except IOError as e:
         print(f"Error modifying game.lua: {e}")
+        raise RuntimeError()
 
 
-print("Starting the process...")
+def modify_game_sources(source_dir, base_dir):
+    """
+    Modify the source files of the game, found in [source_dir], using our own files from [base_dir].
 
-# URL to download the LuaJIT decompiler
-# luajit_decompiler_url = ""
+    Returns the list of modified paths.
+    """
+    # Path to main.lua and game.lua within the extracted files
+    main_lua_path = os.path.join(source_dir, "main.lua")
+    game_lua_path = os.path.join(source_dir, "game.lua")
 
-# Temporary directory for operations
-with tempfile.TemporaryDirectory() as decompiler_dir:
-    # This part was used to download the LuaJit decompiler
-    # luajit_decompiler_path = os.path.join(decompiler_dir, 'luajit-decompiler-v2.exe')
+    # Modify main.lua
+    directories = ["core", "debug", "loader"]
+    modify_main_lua(main_lua_path, base_dir, directories)
+    print("Modification of main.lua complete.")
 
-    # # Download LuaJIT decompiler
-    # if not download_file(luajit_decompiler_url, luajit_decompiler_path):
-    #     print("Failed to download LuaJIT decompiler.")
-    #     sys.exit(1)
+    # Modify main.lua
+    modify_game_lua(game_lua_path)
+    print("Modification of game.lua complete.")
 
-    # print("LuaJIT Decompiler downloaded.")
+    return [main_lua_path, game_lua_path]
 
+
+def download_seven_zip():
+    """"
+    Fetch and extract 7zip, returns (command_path, command_dir) as a tuple
+    """
     # URL to download the 7-Zip suite
     seven_zip_url = "https://github.com/Steamopollys/Steamodded/raw/main/7-zip/7z-repack.zip"
 
     # Temporary directory for 7-Zip suite
-seven_zip_dir = tempfile.TemporaryDirectory()
-print(seven_zip_dir.name)
-print("Downloading and extracting 7-Zip suite...")
-download_file(seven_zip_url, os.path.join(seven_zip_dir.name, "7z-repack.zip"))
-with zipfile.ZipFile(
-    os.path.join(seven_zip_dir.name, "7z-repack.zip"), "r"
-) as zip_ref:
-    zip_ref.extractall(seven_zip_dir.name)
+    seven_zip_dir = tempfile.TemporaryDirectory()
+    print(seven_zip_dir.name)
+    print("Downloading and extracting 7-Zip suite...")
+    download_file(seven_zip_url, os.path.join(seven_zip_dir.name, "7z-repack.zip"))
+    with zipfile.ZipFile(
+            os.path.join(seven_zip_dir.name, "7z-repack.zip"), "r"
+    ) as zip_ref:
+        zip_ref.extractall(seven_zip_dir.name)
 
-# Check the operating system
-#if os.name() == 'Linux':
-#    seven_zip_path = ['wine', os.path.join(seven_zip_dir.name, "7z.exe")]
-#elif os.name == 'nt':
-#    seven_zip_path = os.path.join(seven_zip_dir.name, "7z.exe")
-#else:
-#    # Handle other operating systems or raise an error
-#    raise NotImplementedError("This script only supports Windows and Linux.")
+    # Check the operating system
+    # if os.name() == 'Linux':
+    #     seven_zip_path = ['wine', os.path.join(seven_zip_dir.name, "7z.exe")]
+    # elif os.name == 'nt':
+    #     seven_zip_path = os.path.join(seven_zip_dir.name, "7z.exe")
+    # else:
+    #     # Handle other operating systems or raise an error
+    #     raise NotImplementedError("This script only supports Windows and Linux.")
 
-seven_zip_path = f"{seven_zip_dir.name}/7z.exe"
-
-# Determine the operating system and prepare the 7-Zip command accordingly
-if os.name == 'posix':
-    if platform.system() == 'Darwin':
-        # This is macOS
-        command = "7zz"  # Update this path as necessary for macOS
+    # Determine the operating system and prepare the 7-Zip command accordingly
+    if os.name == 'posix':
+        if platform.system() == 'Darwin':
+            # This is macOS
+            seven_zip_command = "7zz"  # Update this path as necessary for macOS
+        else:
+            # This is Linux or another POSIX-compliant OS
+            seven_zip_command = "7zz"
     else:
-        # This is Linux or another POSIX-compliant OS
-        command = "7zz"
-else:
-    # This is for Windows
-    command = f"{seven_zip_dir.name}/7z.exe"
+        # This is for Windows
+        seven_zip_command = f"{seven_zip_dir.name}/7z.exe"
 
-#command = seven_zip_dir + ["x", "-o" + temp_dir.name, sfx_archive_path]
+    return seven_zip_command, seven_zip_dir
 
-# seven_zip_path = os.path.join(seven_zip_dir.name, "7z.exe")
 
-# Check if the SFX archive path is provided
-if len(sys.argv) < 2:
-    print("Please drag and drop the SFX archive onto this executable.")
+def main():
+    print("Starting the process...")
+
+    # URL to download the LuaJIT decompiler
+    # luajit_decompiler_url = ""
+
+    # Temporary directory for operations
+    with tempfile.TemporaryDirectory() as decompiler_dir:
+        pass
+        # This part was used to download the LuaJit decompiler
+        # luajit_decompiler_path = os.path.join(decompiler_dir, 'luajit-decompiler-v2.exe')
+
+        # # Download LuaJIT decompiler
+        # if not download_file(luajit_decompiler_url, luajit_decompiler_path):
+        #     print("Failed to download LuaJIT decompiler.")
+        #     sys.exit(1)
+
+        # print("LuaJIT Decompiler downloaded.")
+
+    seven_zip_command, seven_zip_dir = download_seven_zip()
+
+    # Check if the SFX archive path is provided
+    if len(sys.argv) < 2:
+        print("Please drag and drop the SFX archive onto this executable.")
+        seven_zip_dir.cleanup()
+        sys.exit(1)
+
+    sfx_archive_path = sys.argv[1]
+    print(f"SFX Archive received: {sfx_archive_path}")
+
+    # Temporary directory for extraction and modification
+    temp_dir = tempfile.TemporaryDirectory()
+    print(temp_dir.name)
+    # Extract the SFX archive
+    subprocess.run([seven_zip_command, "x", f"-o{temp_dir.name}", sfx_archive_path], check=True)
+    print("Extraction complete.")
+
+    # Determine the base directory (where the .exe is located)
+    if getattr(sys, "frozen", False):
+        # Running in a PyInstaller or Nuitka bundle
+        base_dir = os.path.dirname(sys.executable)
+    else:
+        # Running in a normal Python environment
+        base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+
+    # decompile_output_path = os.path.join(temp_dir.name, "output")
+    # os.makedirs(decompile_output_path, exist_ok=True)  # Create the output directory
+    # This part was used to decompile to game data
+    # No longer needed
+    # decompile_lua(luajit_decompiler_path, main_lua_path, decompile_output_path)
+    # print("Decompilation of main.lua complete.")
+
+    modified_files = modify_game_sources(temp_dir.name, base_dir)
+
+    # Update the SFX archive with the modified source files
+    subprocess.run([seven_zip_command, "u", sfx_archive_path, *modified_files], check=True)
+    print("SFX Archive updated.")
+
     seven_zip_dir.cleanup()
-    sys.exit(1)
+    temp_dir.cleanup()
 
-sfx_archive_path = sys.argv[1]
-print(f"SFX Archive received: {sfx_archive_path}")
-
-# Temporary directory for extraction and modification
-temp_dir = tempfile.TemporaryDirectory()
-print(temp_dir.name)
-# Extract the SFX archive
-#subprocess.run([command, "x", "-o" + temp_dir.name, sfx_archive_path])
-subprocess.run([command, "x", f"-o{temp_dir.name}", sfx_archive_path], check=True)
-print("Extraction complete.")
-
-# Path to main.lua and game.lua within the extracted files
-main_lua_path = os.path.join(temp_dir.name, "main.lua")
-game_lua_path = os.path.join(temp_dir.name, "game.lua")
-decompile_output_path = os.path.join(temp_dir.name, "output")
-os.makedirs(decompile_output_path, exist_ok=True)  # Create the output directory
+    print("Process completed successfully.")
 
 
-# This part was used to decompile to game data
-# No longer needed
-# decompile_lua(luajit_decompiler_path, main_lua_path, decompile_output_path)
-# print("Decompilation of main.lua complete.")
+if __name__ == "__main__":
+    try:
+        main()
+    except RuntimeError as e:
+        print("Process failed, see above for errors")
 
-main_lua_output_path = os.path.join(temp_dir.name, "main.lua")
-
-# Determine the base directory (where the .exe is located)
-if getattr(sys, "frozen", False):
-    # Running in a PyInstaller or Nuitka bundle
-    base_dir = os.path.dirname(sys.executable)
-else:
-    # Running in a normal Python environment
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-
-# Modify main.lua
-directories = ["core", "debug", "loader"]
-modify_main_lua(main_lua_output_path, base_dir, directories)
-print("Modification of main.lua complete.")
-
-# Modify main.lua
-modify_game_lua(game_lua_path)
-print("Modification of game.lua complete.")
-
-# Update the SFX archive with the modified main.lua
-#subprocess.run([command, "a", sfx_archive_path, main_lua_output_path])
-subprocess.run([command, "a", sfx_archive_path, main_lua_output_path], check=True)
-# Update the SFX archive with the modified game.lua
-#subprocess.run([command, "a", sfx_archive_path, game_lua_path])
-subprocess.run([command, "a", sfx_archive_path, game_lua_path], check=True)
-print("SFX Archive updated.")
-
-seven_zip_dir.cleanup()
-temp_dir.cleanup()
-
-print("Process completed successfully.")
-print("Press any key to exit...")
-input()
+    print("Press enter to exit...")
+    input()


### PR DESCRIPTION
This PR introduces a `main` function and calls it from an `if __name__ == "__main__"` block. The purpose of this is to ensure that the functions can be imported from other scripts without running the program. This is helpful for testing, or for other tools that may want to cooperatively use the injector.

While writing this I also wanted to make sure I didn't break anything. Unfortunately, the script didn't even work on my machine (Linux). Thus I made a handful of minor semantic changes as well, both to fix this, and to make actually finding such errors easier.

All the changes this PR makes:

- Introduce `main` function, as well as `download_seven_zip` and `modify_game_sources`.
- Changed 7zip command to use `u` instead of `a`, since files are only being updated in the archive
  - Question: 7zip is being downloaded and extracted even the system version is used, could this be fixed?
- Use the parent of the script's directory for `base_dir`, to ensure that the files are actually found when running from source
- Raise exceptions in `except IOError` blocks, because if there was an error then the process likely didn't complete successfully.
- Raise an exception if the `----MOD CORE----` comment is found in the code, to ensure that we don't inject multiple times silently.
- Remove `shutil` import, it is no longer used