### PR TITLE
Added a function wrapper to set_sprites to allow Jokers to have custom atlases without jank

### DIFF
--- a/core/sprite.lua
+++ b/core/sprite.lua
@@ -166,7 +166,7 @@ local set_spritesref = Card.set_sprites
 function Card:set_sprites(_center, _front)
     if _center then 
         if _center.set then
-            if _center.set == 'Joker' and _center.atlas then
+            if (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.atlas then
                 self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS[_center.atlas or 'centers'], self.config.center.pos)
             end
         end

--- a/core/sprite.lua
+++ b/core/sprite.lua
@@ -164,14 +164,15 @@ end
 -- Allows Jokers to have custom atlases
 local set_spritesref = Card.set_sprites
 function Card:set_sprites(_center, _front)
+    set_spritesref(self, _center, _front);
     if _center then 
         if _center.set then
             if (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.atlas then
-                self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS[_center.atlas or 'centers'], self.config.center.pos)
+                self.children.center.atlas = G.ASSET_ATLAS[(_center.atlas or (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.set) or 'centers']
+                self.children.center:set_sprite_pos(_center.pos)
             end
         end
     end
-    set_spritesref(self, _center, _front);
 end
 
 -- ----------------------------------------------

--- a/core/sprite.lua
+++ b/core/sprite.lua
@@ -161,5 +161,18 @@ function Game:set_render_settings()
     SMODS.injectSprites()
 end
 
+-- Allows Jokers to have custom atlases
+local set_spritesref = Card.set_sprites
+function Card:set_sprites(_center, _front)
+    if _center then 
+        if _center.set then
+            if _center.set == 'Joker' and _center.atlas then
+                self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS[_center.atlas or 'centers'], self.config.center.pos)
+            end
+        end
+    end
+    set_spritesref(self, _center, _front);
+end
+
 -- ----------------------------------------------
 -- ------------MOD CORE API SPRITE END-----------


### PR DESCRIPTION
Without this change the "atlas" variable only does something the SECOND time set_sprites is called, and this code is only needed to exist once generically alongside being generic itself so there is no real reason not to have it within steamodded itself