### PR TITLE
Add page selector for mods list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ pyrightconfig.json
 
 /injector/steamodded_injector.dist/
 /injector/steamodded_injector.exe
+/steamodded_injector.build/
+/steamodded_injector.dist/
+/steamodded_injector.onefile-build/
+/steamodded_injector.exe


### PR DESCRIPTION
There is a request thread open on Discord asking to have the Mods menu updated to better handle large mod lists.

This PR adds a page selector to the menu whenever there is at least 1 mod active. The menu will now display 4 mods per page and allow the player to go through the pages to see all their loaded mods.

Additionally, the code used to generate and update a dynamic menu pane has been implemented in a way that should be reusable by other modders. I've tried to add some comments to explain how it works with the Mods menu as an example.

Here are some screenshots of the updated Mods menu:

<img width="1230" alt="UpdateModsMenuPage1" src="https://github.com/Steamopollys/Steamodded/assets/10442064/c73868f4-4082-4331-af2d-2d2c6b43a9b1">
<img width="1103" alt="UpdateModsMenuPage2" src="https://github.com/Steamopollys/Steamodded/assets/10442064/f107b2ac-7c76-41cd-9082-851ad70b074b">

