### PR TITLE
Adding polyglass tooltips to Absolute Deck

### DIFF
--- a/example_mods/AbsoluteDeck.lua
+++ b/example_mods/AbsoluteDeck.lua
@@ -34,7 +34,7 @@ local loc_def = {
 	["text"]={
 		[1]="Start with a Deck",
 		[2]="full of",
-		[3]="{C:attention}Polyglass{} cards"
+		[3]="{C:attention,T:e_polychrome}Poly{}{C:red,T:m_glass}glass{} cards"
 	},
 }
 


### PR DESCRIPTION
Adding tooltip usage to one of the example mods to show other modders how it could be used.
![image](https://github.com/Steamopollys/Steamodded/assets/30300926/134ed513-44f5-48d8-a16a-ebbae26637bb)
