### PR TITLE
Fix card API bugs

### DIFF
--- a/core/suit.lua
+++ b/core/suit.lua
@@ -238,7 +238,6 @@ function SMODS.Card:_extend()
 			end_iter = false
 			if straight_length >= (5 - (four_fingers and 1 or 0)) then
 				straight = true
-				break
 			end
 			if br then break end
 			if not next(vals) then break end

--- a/core/suit.lua
+++ b/core/suit.lua
@@ -927,6 +927,9 @@ function SMODS.Card:_extend()
 	function Card:is_face(from_boss)
 		if self.debuff and not from_boss then return end
 		local val = self.base.value
+		if self.ability.effect == 'Stone Card' and not self.vampired then
+			val = -math.random(100, 1000000)
+		end
 		if next(find_joker('Pareidolia')) or (val and SMODS.Card.RANKS[val] and SMODS.Card.RANKS[val].face) then return true end
 	end
 


### PR DESCRIPTION
Two issues with the Card API code have been raised on Discord

- Playing a Straight containing 5 cards with Four Fingers will cause only 4 cards to score
- Face cards which have been transformed into Stone cards will still trigger Face card jokers like Scary Face incorrectly

This PR fixes both of these issues.

- Four Fingers bug is fixed by removing the break statement which was triggering on the straight check. The base Balatro code does not exit the scoring loop here, so it makes sense this would fix the issue. Tested locally and Four Fingers now appears to behave correctly for both 4 and 5 card Flushes.
- Stone Face cards bug is fixed by using the same logic the base Balatro code does to check the card value before running the actual isFace check. In the base game code, the get_id() call will exit early with this random value if the condition is met and this seems to resolve this issue in local testing.