### PR TITLE
Fixes / utility for joker API

### DIFF
--- a/core/sprite.lua
+++ b/core/sprite.lua
@@ -167,9 +167,21 @@ function Card:set_sprites(_center, _front)
     if _center then
         if _center.set then
             if (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.atlas then
-                self.children.center.atlas = G.ASSET_ATLAS
-                [(_center.atlas or (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.set) or 'centers']
-                self.children.center:set_sprite_pos(_center.pos)
+                if self.params.bypass_discovery_center or (_center.unlocked and _center.discovered) then
+                    self.children.center.atlas = G.ASSET_ATLAS
+                    [(_center.atlas or (_center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher') and _center.set) or 'centers']
+                    self.children.center:set_sprite_pos(_center.pos)
+                elseif not _center.discovered then
+                    self.children.center.atlas = G.ASSET_ATLAS[_center.set]
+                    self.children.center:set_sprite_pos(
+                    (_center.set == 'Joker' and G.j_undiscovered.pos) or 
+                    (_center.set == 'Edition' and G.j_undiscovered.pos) or 
+                    (_center.set == 'Tarot' and G.t_undiscovered.pos) or 
+                    (_center.set == 'Planet' and G.p_undiscovered.pos) or 
+                    (_center.set == 'Spectral' and G.s_undiscovered.pos) or 
+                    (_center.set == 'Voucher' and G.v_undiscovered.pos) or 
+                    (_center.set == 'Booster' and G.booster_undiscovered.pos))
+                end
             end
         end
     end

--- a/core/suit.lua
+++ b/core/suit.lua
@@ -103,7 +103,7 @@ function SMODS.Card:new_suit(name, card_atlas_low_contrast, card_atlas_high_cont
 	if not (type(colour_high_contrast) == 'table') then colour_high_contrast = HEX(colour_high_contrast) end
 	G.C.SO_1[name] = colour_low_contrast
 	G.C.SO_2[name] = colour_high_contrast
-	G.C.SUITS[name] = G.C["SO_" .. (G.SETTINGS.colourblind_option and 2 or 1)][name]
+    G.C.SUITS[name] = G.C["SO_" .. (G.SETTINGS.colourblind_option and 2 or 1)][name]
 	for _, v in pairs(SMODS.Card.RANKS) do
 		G.P_CARDS[prefix .. '_' .. (v.suffix or v.value)] = {
 			name = v.value .. ' of ' .. name,
@@ -117,7 +117,7 @@ function SMODS.Card:new_suit(name, card_atlas_low_contrast, card_atlas_high_cont
 		}
 	end
 	G.localization.misc['suits_plural'][name] = name
-	G.localization.misc['suits_singular'][name] = name
+	G.localization.misc['suits_singular'][name] = name:match("(.+)s$")
 	return SMODS.Card.SUITS[name]
 end
 
@@ -177,14 +177,23 @@ end
 
 function SMODS.Card:_extend()
 	local Game_init_game_object = Game.init_game_object
-	function Game:init_game_object()
-		local t = Game_init_game_object(self)
-		t.cards_played = {}
-		for k, v in pairs(SMODS.Card.RANKS) do
-			t.cards_played[k] = { suits = {}, total = 0 }
+    function Game:init_game_object()
+        local t = Game_init_game_object(self)
+        t.cards_played = {}
+        for k, v in pairs(SMODS.Card.RANKS) do
+            t.cards_played[k] = { suits = {}, total = 0 }
+        end
+        return t
+    end
+	
+	local loc_colour_ref = loc_colour
+	function loc_colour(_c, _default)
+        loc_colour_ref(_c, _default)
+		for k,_ in pairs(SMODS.Card.SUITS) do
+			G.ARGS.LOC_COLOURS[k:lower()] = G.ARGS.LOC_COLOURS[k:lower()] or G.C.SUITS[k]
 		end
-		return t
-	end
+		return G.ARGS.LOC_COLOURS[_c] or _default or G.C.UI.TEXT_DARK
+	  end
 
 	function get_flush(hand)
 		local ret = {}


### PR DESCRIPTION
- Allows usage of the `effect` field with custom jokers, as well as explicit passing of an atlas, to allow all jokers of a mod to share an atlas.
- As a result, the `effect` method previously used for the `set_ability` function was renamed to `set_ability` to be more descriptive and ensure compatibility.
- An interface for `Card:generate_UIBox_ability_table` has been introduced in the form of `SMODS.Joker:loc_def` to reduce boilerplate.
- Fix visual issues with undiscovered modded jokers in the collection