### PR TITLE
fix: add StackTracePlus.lua to lovely.toml

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -21,7 +21,8 @@ sources = [
     "core/deck.lua",
     "core/joker.lua",
     "core/sprite.lua",
-	  "core/suit.lua",
+    "core/StackTracePlus.lua",
+    "core/suit.lua",
     "debug/debug.lua",
     "loader/loader.lua",
 ]


### PR DESCRIPTION
Fixes a crash when using lovely.