### PR TITLE
feat: add in logic for adding seals into the pack opening

### DIFF
--- a/core/seal.lua
+++ b/core/seal.lua
@@ -74,3 +74,138 @@ function get_badge_colour(key)
 	end
     return fromRef
 end
+
+-- Orginally from @axbolduc
+-- Add the seal to be randomly generated in standard packs
+-- This is bad because we have to reimplement the seal generation logic for standard packs
+-- for my seal to be randomly generated. Because of how the logic is implemented in the base
+-- game we cannot call the base function or else we'll end up with twice the amount of cards in the pack.
+-- This means that any other mod that touches the standard pack may be wiped out
+local card_open_ref = Card.open
+function Card:open()
+    if self.ability.set == "Booster" and not self.ability.name:find('Standard') then
+        return card_open_ref(self)
+    else
+        stop_use()
+        G.STATE_COMPLETE = false
+        self.opening = true
+
+        if not self.config.center.discovered then
+            discover_card(self.config.center)
+        end
+        self.states.hover.can = false
+        G.STATE = G.STATES.STANDARD_PACK
+        G.GAME.pack_size = self.ability.extra
+
+        G.GAME.pack_choices = self.config.center.config.choose or 1
+
+        if self.cost > 0 then
+            G.E_MANAGER:add_event(Event({
+                trigger = 'after',
+                delay = 0.2,
+                func = function()
+                    inc_career_stat('c_shop_dollars_spent', self.cost)
+                    self:juice_up()
+                    return true
+                end
+            }))
+            ease_dollars(-self.cost)
+        else
+            delay(0.2)
+        end
+
+        G.E_MANAGER:add_event(Event({
+            trigger = 'after',
+            delay = 0.4,
+            func = function()
+                self:explode()
+                local pack_cards = {}
+
+                G.E_MANAGER:add_event(Event({
+                    trigger = 'after',
+                    delay = 1.3 * math.sqrt(G.SETTINGS.GAMESPEED),
+                    blockable = false,
+                    blocking = false,
+                    func = function()
+                        local _size = self.ability.extra
+
+                        for i = 1, _size do
+                            local card = nil
+                            card = create_card(
+                                (pseudorandom(pseudoseed('stdset' .. G.GAME.round_resets.ante)) > 0.6) and
+                                "Enhanced" or
+                                "Base", G.pack_cards, nil, nil, nil, true, nil, 'sta')
+                            local edition_rate = 2
+                            local edition = poll_edition('standard_edition' .. G.GAME.round_resets.ante,
+                                edition_rate,
+                                true)
+                            card:set_edition(edition)
+                            local seal_rate = 10
+                            local seal_poll = pseudorandom(pseudoseed('stdseal' .. G.GAME.round_resets.ante))
+                            if seal_poll > 1 - 0.02 * seal_rate then
+                                -- This is basically the only code that is changed
+                                local seal_type = pseudorandom(
+                                    pseudoseed('stdsealtype' .. G.GAME.round_resets.ante),
+                                    1,
+                                    #G.P_CENTER_POOLS['Seal']
+                                )
+
+                                local sealName
+                                for k, v in pairs(G.P_SEALS) do
+                                    if v.order == seal_type then sealName = k end
+                                end
+
+                                if sealName == nil then sendDebugMessage("SEAL NAME IS NIL") end
+
+                                card:set_seal(sealName)
+                                -- End changed code
+                            end
+                            card.T.x = self.T.x
+                            card.T.y = self.T.y
+                            card:start_materialize({ G.C.WHITE, G.C.WHITE }, nil, 1.5 * G.SETTINGS.GAMESPEED)
+                            pack_cards[i] = card
+                        end
+                        return true
+                    end
+                }))
+
+                G.E_MANAGER:add_event(Event({
+                    trigger = 'after',
+                    delay = 1.3 * math.sqrt(G.SETTINGS.GAMESPEED),
+                    blockable = false,
+                    blocking = false,
+                    func = function()
+                        if G.pack_cards then
+                            if G.pack_cards and G.pack_cards.VT.y < G.ROOM.T.h then
+                                for k, v in ipairs(pack_cards) do
+                                    G.pack_cards:emplace(v)
+                                end
+                                return true
+                            end
+                        end
+                    end
+                }))
+
+                for i = 1, #G.jokers.cards do
+                    G.jokers.cards[i]:calculate_joker({ open_booster = true, card = self })
+                end
+
+                if G.GAME.modifiers.inflation then
+                    G.GAME.inflation = G.GAME.inflation + 1
+                    G.E_MANAGER:add_event(Event({
+                        func = function()
+                            for k, v in pairs(G.I.CARD) do
+                                if v.set_cost then v:set_cost() end
+                            end
+                            return true
+                        end
+                    }))
+                end
+
+                return true
+            end
+        }))
+    end
+end
+
+


### PR DESCRIPTION
This fix is needed to override the original code for the `card.open` function so seals can be added to cards when a pack is opened. Currently only the original seals will be added to cards so even though the seal is added to the game it will not appear in runs. 

This is probably not the correct way of implementing this and I am happy to change it to a new file called `pack.lua` but I figured its better to get some eyes on it first. 