### PR TITLE
Fully custom error handler

### DIFF
--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -452,10 +452,29 @@ function getDebugInfoForCrash()
     if lovely_success then
         info = info .. "\nLovely Version: " .. lovely.version
     end
-    info = info .. "\nSteamodded Mods:"
-    for k, v in pairs(SMODS.MODS) do
-        info = info .. "\n    " .. k .. ": " .. v.name .. " By " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
-                   (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. "]"
+    if SMODS.MODS then
+        info = info .. "\nSteamodded Mods:"
+        for k, v in pairs(SMODS.MODS) do
+            info = info .. "\n    " .. k .. ": " .. v.name .. " By " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
+                       (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. "]"
+            local debugInfo = SMODS.DebugInfo[v.id]
+            if debugInfo then
+                if type(debugInfo) == "string" then
+                    if #debugInfo ~= 0 then
+                        info = info .. "\n        " .. debugInfo
+                    end
+                elseif type(debugInfo) == "table" then
+                    for k, v in pairs(debugInfo) do
+                        if type(v) ~= nil then
+                            v = tostring(v)
+                        end
+                        if #v ~= 0 then
+                            info = info .. "\n        " .. k .. ": " .. v
+                        end
+                    end
+                end
+            end
+        end
     end
     return info
 end
@@ -465,6 +484,7 @@ function injectStackTrace()
         return
     end
     stackTraceAlreadyInjected = true
+    SMODS.DebugInfo = {}
     local STP = loadStackTracePlus()
     local utf8 = require("utf8")
 
@@ -661,7 +681,6 @@ function injectStackTrace()
         end
 
     end
-
 end
 
 -- ----------------------------------------------

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -448,6 +448,9 @@ local stackTraceAlreadyInjected = false
 
 function getDebugInfoForCrash()
     local info = "Additional Context:\nBalatro Version: " .. VERSION .. "\nModded Version: " .. MODDED_VERSION
+    local major, minor, revision, codename = love.getVersion()
+    info = info .. string.format("\nLove2D Version: %d.%d.%d", major, minor, revision)
+
     local lovely_success, lovely = pcall(require, "lovely")
     if lovely_success then
         info = info .. "\nLovely Version: " .. lovely.version

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -658,11 +658,13 @@ function injectStackTrace()
                     scrollOffset = endHeight
                 elseif e == "wheelmoved" then
                     scrollUp(b * 20)
-                elseif e == "gamepadpressed" and a == "dpdown" then
+                elseif e == "gamepadpressed" and b == "dpdown" then
                     scrollDown()
-                elseif e == "gamepadpressed" and a == "dpup" then
+                elseif e == "gamepadpressed" and b == "dpup" then
                     scrollUp()
-                elseif e == "gamepadpressed" and (a == "back" or a == "start") then
+                elseif e == "gamepadpressed" and b == "a" then
+                    copyToClipboard()
+                elseif e == "gamepadpressed" and (b == "b" or b == "back" or b == "start") then
                     return 1
                 elseif e == "touchpressed" then
                     local name = love.window.getTitle()

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -457,6 +457,8 @@ function injectStackTrace()
     function love.errorhandler(msg)
         msg = tostring(msg)
 
+        sendErrorMessage("Oops! The game crashed\n" .. STP.stacktrace(msg), 'StackTrace')
+
         if not love.window or not love.graphics or not love.event then
             return
         end
@@ -503,7 +505,7 @@ function injectStackTrace()
 
         local err = {}
 
-        table.insert(err, "Error: ")
+        table.insert(err, "Oops! The game crashed:")
         table.insert(err, sanitizedmsg)
 
         if #sanitizedmsg ~= #msg then

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -658,6 +658,12 @@ function injectStackTrace()
                     scrollOffset = endHeight
                 elseif e == "wheelmoved" then
                     scrollUp(b * 20)
+                elseif e == "gamepadpressed" and a == "dpdown" then
+                    scrollDown()
+                elseif e == "gamepadpressed" and a == "dpup" then
+                    scrollUp()
+                elseif e == "gamepadpressed" and (a == "back" or a == "start") then
+                    return 1
                 elseif e == "touchpressed" then
                     local name = love.window.getTitle()
                     if #name == 0 or name == "Untitled" then

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -445,6 +445,21 @@ end
 
 -- Note: The below code is not from the original StackTracePlus.lua
 local stackTraceAlreadyInjected = false
+
+function getDebugInfoForCrash()
+    local info = "Additional Context:\nBalatro Version: " .. VERSION .. "\nModded Version: " .. MODDED_VERSION
+    local lovely_success, lovely = pcall(require, "lovely")
+    if lovely_success then
+        info = info .. "\nLovely Version: " .. lovely.version
+    end
+    info = info .. "\nSteamodded Mods:"
+    for k, v in pairs(SMODS.MODS) do
+        info = info .. "\n    " .. k .. ": " .. v.name .. " By " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
+                   (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. "]"
+    end
+    return info
+end
+
 function injectStackTrace()
     if (stackTraceAlreadyInjected) then
         return
@@ -512,6 +527,15 @@ function injectStackTrace()
             table.insert(err, "Invalid UTF-8 string in error message.")
         end
 
+        local success, msg = pcall(getDebugInfoForCrash)
+        if success and msg then
+            table.insert(err, '\n' .. msg)
+            sendInfoMessage(msg, 'StackTrace')
+        else
+            table.insert(err, "\n" .. "Failed to get additional context :/")
+            sendErrorMessage("Failed to get additional context :/\n" .. msg, 'StackTrace')
+        end
+
         for l in trace:gmatch("(.-)\n") do
             if not l:match("boot.lua") then
                 l = l:gsub("stack traceback:", "Traceback\n")
@@ -556,7 +580,9 @@ function injectStackTrace()
             local lineHeight = font:getHeight()
             local atBottom = scrollOffset == endHeight and scrollOffset ~= 0
             endHeight = #lines * lineHeight - love.graphics.getHeight() + pos * 2
-            if(endHeight < 0) then endHeight = 0 end
+            if (endHeight < 0) then
+                endHeight = 0
+            end
             if scrollOffset > endHeight or atBottom then
                 scrollOffset = endHeight
             end


### PR DESCRIPTION
This PR modifies the better stack trace, to use its own implementation for rendering the error. This provides the following benefits
- No more hacks to show the stack trace (and it has consistent output whether or not the user has debug mode enabled)
- Won't send crash logs to localthunk
- Log can be copied with ctrl + c
- Log can be scrolled if its too big for the screen
- Now shows some other info, which might help in debugging. Namely: Balatro Version, Steamodded Version, Lovely Version (if applicable), list of steamodded mods.
- Much easier to add more functionality in the future, if we so desire

I've also made a new api. Mod's can now set SMOD.DebugInfo.modid to either a string, or table of strings, and the crash handler will display them beneath the mod. This is designed for mods to show whatever they want. This can include things like version numbers, internal states, and anything else they might find useful to show.