### PR TITLE
Crash handler improvements

### DIFF
--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -487,7 +487,6 @@ function injectStackTrace()
         return
     end
     stackTraceAlreadyInjected = true
-    SMODS.DebugInfo = {}
     local STP = loadStackTracePlus()
     local utf8 = require("utf8")
 
@@ -701,6 +700,8 @@ function injectStackTrace()
 
     end
 end
+
+injectStackTrace()
 
 -- ----------------------------------------------
 -- --------MOD CORE API STACKTRACE END-----------

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -458,9 +458,8 @@ function getDebugInfoForCrash()
     if SMODS.mod_list then
         info = info .. "\nSteamodded Mods:"
         for k, v in ipairs(SMODS.mod_list) do
-            info = info .. "\n    " .. k .. ": " ..
-                v.name .. " by " .. concatAuthors(v.author) ..
-                " [ID: " .. v.id .. (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. "]"
+            info = info .. "\n    " .. k .. ": " .. v.name .. " by " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
+                       (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. "]"
             local debugInfo = v.debug_info
             if debugInfo then
                 if type(debugInfo) == "string" then
@@ -561,10 +560,7 @@ function injectStackTrace()
         end
 
         for l in trace:gmatch("(.-)\n") do
-            if not l:match("boot.lua") then
-                l = l:gsub("stack traceback:", "Traceback\n")
-                table.insert(err, l)
-            end
+            table.insert(err, l)
         end
 
         local p = table.concat(err, "\n")
@@ -597,6 +593,7 @@ function injectStackTrace()
         end
 
         local pos = 70
+        local arrowSize = 20
 
         local function calcEndHeight()
             local font = love.graphics.getFont()
@@ -619,6 +616,16 @@ function injectStackTrace()
             love.graphics.clear(G.C.BLACK)
             calcEndHeight()
             love.graphics.printf(p, pos, pos - scrollOffset, love.graphics.getWidth() - pos * 2)
+            if scrollOffset ~= endHeight then
+            love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2), love.graphics.getHeight() - arrowSize,
+                love.graphics.getWidth() - (pos / 2) + arrowSize, love.graphics.getHeight() - (arrowSize * 2),
+                love.graphics.getWidth() - (pos / 2) - arrowSize, love.graphics.getHeight() - (arrowSize * 2))
+            end
+            if scrollOffset ~= 0 then
+            love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2), arrowSize,
+                love.graphics.getWidth() - (pos / 2) + arrowSize, arrowSize * 2,
+                love.graphics.getWidth() - (pos / 2) - arrowSize, arrowSize * 2)
+            end
             love.graphics.present()
         end
 

--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -196,8 +196,6 @@ local function initializeModUIFunctions()
 end
 
 function initSteamodded()
-    boot_print_stage("Loading Stack Trace")
-    injectStackTrace()
     boot_print_stage("Loading APIs")
     loadAPIs()
     boot_print_stage("Loading Mods")

--- a/lovely/core.toml
+++ b/lovely/core.toml
@@ -18,10 +18,10 @@ target = "main.lua"
 position = "append"
 sources = [
 	"core/core.lua",
+	"core/StackTracePlus.lua",
 	"core/game_object.lua",
 	"core/sound.lua",
 	"core/sticker.lua",
-	"core/StackTracePlus.lua",
 	"debug/debug.lua",
 	"loader/loader.lua",
 ]


### PR DESCRIPTION
This adds some improvements to the crash handler. Namely:
Arrows indicating when you can scroll (a lot of people didn't realize you could. Hopefully this helps)

https://github.com/Steamopollys/Steamodded/assets/33164598/62ae8f04-0ff4-4446-91c0-5f6c0d922249

Loads the crash handler much sooner. I made it init itself immediately after injecting, and also caused it to be injected sooner (I tried loading it before core, but then it threw an error about the filesystem not being initalized, if there was an error in core, so I just let it be after).

A few minor cleanups.