### PR TITLE
Better error chunk names

### DIFF
--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -144,6 +144,7 @@ function loadMods(modsDirectory)
                     if sane then
                         boot_print_stage('Saving Mod Info: ' .. mod.id)
                         mod.path = directory .. '/'
+                        mod.main_file = filename
                         mod.display_name = mod.display_name or mod.name
                         used_prefixes[mod.prefix] = mod.id
                         mod.content = file_content
@@ -240,7 +241,7 @@ function loadMods(modsDirectory)
             if mod.can_load then
                 boot_print_stage('Loading Mod: ' .. mod.id)
                 SMODS.current_mod = mod
-                assert(load(mod.content))()
+                assert(load(mod.content, "=[SMODS " .. mod.id .. ' "' .. mod.main_file .. '"]'))()
             else
                 boot_print_stage('Failed to load Mod: ' .. mod.id)
                 sendWarnMessage(string.format("Mod %s was unable to load: %s%s%s", mod.id,


### PR DESCRIPTION
This improves the error message 
`--- STEAMODDED HEADER...:25: Funny Crash go BRRRRRRRRRRR` > `[SMODS Crashing "Crashing.lua"]:25: Funny Crash go BRRRRRRRRRRR`

For the name, the vars are `<const SMODS> <Mod ID> "<Mod filename>"`. 

A side effect of this is the mod in the stack trace is a bit different. 
```
(4) Lua method 'key_press_update' at line 25 of mod Crashing (Crashing) 
Local variables:
 self = table: 0x047af920  {dragging:table: 0x047afaa0, pressed_keys:table: 0x047affe0, held_keys:table: 0x047b0540 (more...)}
 key = string: "["
 dt = number: 0.0210579
```
to
```
(4) Lua method 'key_press_update' at file 'Crashing.lua:25' (from mod with id Crashing)
Local variables:
 self = table: 0x042e6258  {lock_input:false, clicked:table: 0x044c0fb0, focused:table: 0x04412c50 (more...)}
 key = string: "["
 dt = number: 0.0211131
```
I could probably hack together something that lets me get the mod name again, but it, this keeps the code simple, and i don't think it's necessary, especially with the addition of a filename.