### PR TITLE
Add a few QoL functions

### DIFF
--- a/lovely/back.toml
+++ b/lovely/back.toml
@@ -51,3 +51,18 @@ payload = '''
 		obj:apply()
 	end
 '''
+
+# Back:trigger_effect(args)
+[[patches]]
+[patches.pattern]
+target = 'back.lua'
+pattern = "if not args then return end"
+position = 'after'
+match_indent = true
+payload = '''
+	local obj = self.effect.center
+	if obj.trigger_effect and type(obj.trigger_effect) == 'function' then
+		local o = obj:trigger_effect(args)
+		if o then return o end
+	end
+'''

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -524,3 +524,64 @@ if obj.load and type(obj.load) == 'function' then
 	obj:load(self, cardTable, other_card)
 elseif self.config.center.name == "Half Joker" then
 '''
+
+# Card:calculate_dollar_bonus()
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "if self.ability.name == 'Cloud 9' and self.ability.nine_tally and self.ability.nine_tally > 0 then"
+position = "before"
+match_indent = true
+payload = '''
+--asdf
+local obj = self.config.center
+if obj.calc_dollar_bonus and type(obj.calc_dollar_bonus) == 'function' then
+    return obj:calc_dollar_bonus(self)
+end
+'''
+
+# end_round()
+[[patches]]
+[patches.regex]
+target = 'functions/state_events.lua'
+pattern = '''(?<indent>[\t ]*)reset_castle_card\(\)'''
+line_prepend = '$indent'
+position = 'after'
+payload = '''
+for _, mod in ipairs(SMODS.mod_list) do
+	if mod.reset_game_globals and type(mod.reset_game_globals) == 'function' then
+		mod.reset_game_globals(false)
+	end
+end
+'''
+
+# Game:start_run()
+[[patches]]
+[patches.regex]
+target = 'game.lua'
+pattern = '''(?<indent>[\t ]*)reset_castle_card\(\)'''
+line_prepend = '$indent'
+position = 'after'
+payload = '''
+for _, mod in ipairs(SMODS.mod_list) do
+	if mod.reset_game_globals and type(mod.reset_game_globals) == 'function' then
+		mod.reset_game_globals(true)
+	end
+end
+'''
+
+# Card:set_debuff()
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+pattern = "function Card:set_debuff(should_debuff)"
+position = 'after'
+match_indent = true
+payload = '''
+for _, mod in ipairs(SMODS.mod_list) do
+	if mod.set_debuff and type(mod.set_debuff) == 'function' then
+		local omit_base_debuff_check = mod.set_debuff(self, should_debuff)
+		if omit_base_debuff_check ~= nil then return end --return anything other than nil to stop the game's base logic for card debuffing
+	end
+end
+'''

--- a/lovely/payout_arg.toml
+++ b/lovely/payout_arg.toml
@@ -3,22 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = 0
 
-### calc_dollar_bonus add-on for jokers
-# Card:calculate_dollar_bonus()
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "if self.ability.name == 'Cloud 9' and self.ability.nine_tally and self.ability.nine_tally > 0 then"
-position = "before"
-match_indent = true
-payload = '''
---asdf
-local obj = self.config.center
-if obj.calc_dollar_bonus and type(obj.calc_dollar_bonus) == 'function' then
-    return obj.calc_dollar_bonus(self)
-end
-'''
-
 ### Payout Arg API
 # G.FUNCS.evaluate_play()
 [[patches]]


### PR DESCRIPTION
Adds a couple misc functions
- `trigger_effect`: Used by decks to calculate active effects through the `Back:trigger_effect` function (used by Anaglyph and Plasma Deck). 
- `reset_game_globals`: Used for setting global variables that chance per round (such as the suit/rank globals used by Jokers like Mail-in Rebate, The Idol, etc.). `first_pass` is to check for if the function is called when `Game:start_run` is. 
- `set_debuff`: Used to add custom logic for debuffing cards. 
Also moved `calc_dollar_bonus` from payout_lua lovely file into center lovely file because nobody noticed it existed xdd. 