### PR TITLE
feat: prevent crash with corrupt/invalid saves

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -24,3 +24,20 @@ pattern = "(?<indent>[\t ]*)if not \\(st.init and st:init\\(\\)\\) then\n[\t ]*(
 position = 'at'
 root_capture = 'quit'
 payload = 'st = nil'
+
+
+## Prevents the game from crashing when hitting play with a corrupt/invalid save file
+# G.FUNCS.can_continue(e)
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+pattern = "if G.SAVED_GAME ~= nil then G.SAVED_GAME = STR_UNPACK(G.SAVED_GAME) end"
+position = 'after'
+match_indent = true
+payload = """
+if G.SAVED_GAME == nil then 
+    e.config.colour = G.C.UI.BACKGROUND_INACTIVE
+    e.config.button = nil
+    return _can_continue
+end
+"""


### PR DESCRIPTION
This pr adds a check to the game that prevents it from crashing when pressing the play button with an invalid/corrupted save.jkr, allowing people to make a new game. This is technically a balatro bug, but invalid saves are more common when using mods, so I figured it would be nice to fix.

A before and after:

https://github.com/Steamopollys/Steamodded/assets/33164598/db323baf-b68b-47c5-95bf-3c1210c6d1ae

Ping me on discord if you want a corrupt save to test with (github doesn't let me upload .jkr files)