### PR TITLE
Fix shader keys auto adding mod prefix

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -22,7 +22,7 @@ function loadAPIs()
     function SMODS.GameObject:__call(o)
         o = o or {}
         o.mod = SMODS.current_mod
-        if o.mod and not o.raw_atlas_key and not (o.mod.omit_mod_prefix or o.omit_mod_prefix) then
+        if o.mod and not o.raw_atlas_key and not (o.mod.omit_mod_prefix or o.omit_mod_prefix) and not o['shader'] then
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
                 if o[v] then o[v] = ('%s_%s'):format(o.mod.prefix, o[v]) end
             end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -22,7 +22,7 @@ function loadAPIs()
     function SMODS.GameObject:__call(o)
         o = o or {}
         o.mod = SMODS.current_mod
-        if o.mod and not o.raw_atlas_key and not (o.mod.omit_mod_prefix or o.omit_mod_prefix) and not o['shader'] then
+        if o.mod and not o.raw_atlas_key and not (o.mod.omit_mod_prefix or o.omit_mod_prefix) then
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
                 if o[v] then o[v] = ('%s_%s'):format(o.mod.prefix, o[v]) end
             end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -27,9 +27,6 @@ function loadAPIs()
                 if o[v] then o[v] = ('%s_%s'):format(o.mod.prefix, o[v]) end
             end
         end
-        if o.mod and not o.raw_shader_key and not (o.mod.omit_mod_prefix or o.omit_mod_prefix) then
-            if o['shader'] then o['shader'] = ('%s_%s'):format(o.mod.prefix, o['shader']) end
-        end
         setmetatable(o, self)
         for _, v in ipairs(o.required_params or {}) do
             assert(not (o[v] == nil), ('Missing required parameter for %s declaration: %s'):format(o.set, v))


### PR DESCRIPTION
Shader keys should now be referenced as `modprefix_shaderkey`