### PR TITLE
Rationalize prefixes

### DIFF
--- a/core/core.lua
+++ b/core/core.lua
@@ -5,7 +5,7 @@ SMODS = {}
 SMODS.GUI = {}
 SMODS.GUI.DynamicUIManager = {}
 
-MODDED_VERSION = "1.0.0-ALPHA-0702a-STEAMODDED"
+MODDED_VERSION = "1.0.0-ALPHA-0706a-STEAMODDED"
 
 function STR_UNPACK(str)
 	local chunk, err = loadstring(str)

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -47,31 +47,34 @@ function loadAPIs()
         end
     end
 
-    function SMODS.add_prefixes(cls, obj)
+    function SMODS.add_prefixes(cls, obj, from_take_ownership)
         if obj.prefix_config == false then return end
         -- keep class defaults for unmodified keys in prefix_config
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
-        obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, obj.mod and obj.mod.prefix_config)
+        local mod = SMODS.current_mod
+        obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, mod and mod.prefix_config)
         obj.prefix_config = obj.prefix_config or {}
         obj.original_key = obj.key
         local key_cfg = obj.prefix_config.key
         if key_cfg ~= false then
             if type(key_cfg) ~= 'table' then key_cfg = {} end
-            if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
-            SMODS.modify_key(obj, obj.mod and obj.mod.prefix, key_cfg.mod)
+            if not from_take_ownership then
+                if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
+                SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
+            end
             SMODS.modify_key(obj, cls.class_prefix, key_cfg.class)
         end
         local atlas_cfg = obj.prefix_config.atlas
         if atlas_cfg ~= false then
             if type(atlas_cfg) ~= 'table' then atlas_cfg = {} end
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
-                if rawget(obj, v) then SMODS.modify_key(obj, obj.mod and obj.mod.prefix, atlas_cfg[v], v) end
+                if rawget(obj, v) then SMODS.modify_key(obj, mod and mod.prefix, atlas_cfg[v], v) end
             end
         end
         local shader_cfg = obj.prefix_config.shader
-        SMODS.modify_key(obj, obj.mod and obj.mod.prefix, shader_cfg, 'shader')
+        SMODS.modify_key(obj, mod and mod.prefix, shader_cfg, 'shader')
         local card_key_cfg = obj.prefix_config.card_key
-        SMODS.modify_key(obj, obj.mod and obj.mod.prefix, card_key_cfg, 'card_key')
+        SMODS.modify_key(obj, mod and mod.prefix, card_key_cfg, 'card_key')
     end
 
     function SMODS.GameObject:check_duplicate_register()
@@ -151,7 +154,7 @@ function loadAPIs()
         assert(obj.key == nil or obj.key == key)
         obj.key = key
         assert(obj.mod == nil)
-        SMODS.add_prefixes(self, obj)
+        SMODS.add_prefixes(self, obj, true)
         key = obj.key
         local orig_o = self.obj_table[key] or (self.get_obj and self:get_obj(key))
         if not orig_o then

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -162,7 +162,7 @@ function loadAPIs()
             o.rarity_original = o.rarity
         end
         for k, v in pairs(obj) do o[k] = v end
-        if o.mod and not (conf == false or (conf and conf.atlas == false) or (conf.atlas and conf.atlas == false)) then
+        if o.mod and not (conf == false or (conf and conf.atlas == false)) then
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
                 -- was a new atlas provided with this call?
 

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -46,7 +46,7 @@ function loadAPIs()
         end
     end
 
-    function SMODS.add_prefixes(cls, obj)
+    function SMODS.add_prefixes(cls, obj, from_take_ownership)
         if obj.prefix_config == false then return end
         -- keep class defaults for unmodified keys in prefix_config
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
@@ -57,8 +57,10 @@ function loadAPIs()
         local key_cfg = obj.prefix_config.key
         if key_cfg ~= false then
             if type(key_cfg) ~= 'table' then key_cfg = {} end
-            if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
-            SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
+            if not from_take_ownership then
+                if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
+                SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
+            end
             SMODS.modify_key(obj, cls.class_prefix, key_cfg.class)
         end
         local atlas_cfg = obj.prefix_config.atlas
@@ -86,7 +88,7 @@ function loadAPIs()
     function SMODS.GameObject:check_duplicate_key()
         if self.obj_table[self.key] or (self.get_obj and self:get_obj(self.key)) then
             sendWarnMessage(('Object %s has the same key as an existing object, not registering.'):format(self.key), self.set)
-            sendWarnMessage('If you want to modify an existing object, use take_ownership()')
+            sendWarnMessage('If you want to modify an existing object, use take_ownership()', self.set)
             return true
         end
         return false
@@ -148,7 +150,7 @@ function loadAPIs()
     --- Takes control of vanilla objects. Child class must implement get_obj for this to function.
     function SMODS.GameObject:take_ownership(key, obj, silent)
         obj.key = key
-        SMODS.add_prefixes(self, obj)
+        SMODS.add_prefixes(self, obj, true)
         print(tprint(obj))
         key = obj.key
         if self.check_duplicate_register(obj) then return end
@@ -512,7 +514,7 @@ function loadAPIs()
             table.sort(G.P_CENTER_POOLS[self.set], function(a, b) return a.stake_level < b.stake_level end)
             G.C.STAKES = {}
             for i = 1, #G.P_CENTER_POOLS[self.set] do
-                G.C.STAKES[i] = G.P_CENTER_POOLS[self.set][i].color or G.C.WHITE
+                G.C.STAKES[i] = G.P_CENTER_POOLS[self.set][i].colour or G.C.WHITE
             end
             self.injected = true
         end,

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -49,14 +49,14 @@ function loadAPIs()
         obj.original_key = obj.key
         local key_cfg = obj.prefix_config.key
         if key_cfg ~= false then
-            if type(key_cfg ~= 'table') then key_cfg = {} end
+            if type(key_cfg) ~= 'table' then key_cfg = {} end
             if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
             SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
             SMODS.modify_key(obj, obj.class_prefix, key_cfg.class)
         end
         local atlas_cfg = obj.prefix_config.atlas
         if atlas_cfg ~= false then
-            if type(atlas_cfg ~= 'table') then atlas_cfg = {} end
+            if type(atlas_cfg) ~= 'table' then atlas_cfg = {} end
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
                 if rawget(obj, v) then SMODS.modify_key(obj, mod and mod.prefix, atlas_cfg[v], v) end
             end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -55,7 +55,7 @@ function loadAPIs()
         end
         local atlas_cfg = self.prefix_config.atlas
         if atlas_cfg ~= false then
-            if type(atlas_cfg ~= 'table') then key_cfg = {} end
+            if type(atlas_cfg ~= 'table') then atlas_cfg = {} end
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
                 self:modify_key(self.mod and self.mod.prefix, atlas_cfg[v], v)
             end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -35,7 +35,7 @@ function loadAPIs()
 
     function SMODS.modify_key(obj, prefix, condition, key)
         key = key or 'key'
-        if condition ~= false and obj[key] and prefix then
+        if condition and obj[key] and prefix then
             obj[key] = prefix .. '_' .. obj[key]
         end
     end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -35,7 +35,8 @@ function loadAPIs()
 
     function SMODS.modify_key(obj, prefix, condition, key)
         key = key or 'key'
-        if condition and obj[key] and prefix then
+        -- condition == nil counts as true
+        if condition ~= false and obj[key] and prefix then
             obj[key] = prefix .. '_' .. obj[key]
         end
     end

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -51,7 +51,6 @@ function loadAPIs()
         -- keep class defaults for unmodified keys in prefix_config
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, obj.mod and obj.mod.prefix_config)
-        local mod = SMODS.current_mod
         obj.prefix_config = obj.prefix_config or {}
         obj.original_key = obj.key
         local key_cfg = obj.prefix_config.key
@@ -59,7 +58,7 @@ function loadAPIs()
             if type(key_cfg) ~= 'table' then key_cfg = {} end
             if not from_take_ownership then
                 if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
-                SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
+                SMODS.modify_key(obj, obj.mod and obj.mod.prefix, key_cfg.mod)
             end
             SMODS.modify_key(obj, cls.class_prefix, key_cfg.class)
         end
@@ -67,13 +66,13 @@ function loadAPIs()
         if atlas_cfg ~= false then
             if type(atlas_cfg) ~= 'table' then atlas_cfg = {} end
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
-                if rawget(obj, v) then SMODS.modify_key(obj, mod and mod.prefix, atlas_cfg[v], v) end
+                if rawget(obj, v) then SMODS.modify_key(obj, obj.mod and obj.mod.prefix, atlas_cfg[v], v) end
             end
         end
         local shader_cfg = obj.prefix_config.shader
-        SMODS.modify_key(obj, mod and mod.prefix, shader_cfg, 'shader')
+        SMODS.modify_key(obj, obj.mod and obj.mod.prefix, shader_cfg, 'shader')
         local card_key_cfg = obj.prefix_config.card_key
-        SMODS.modify_key(obj, mod and mod.prefix, card_key_cfg, 'card_key')
+        SMODS.modify_key(obj, obj.mod and obj.mod.prefix, card_key_cfg, 'card_key')
     end
 
     function SMODS.GameObject:check_duplicate_register()

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -21,14 +21,15 @@ function loadAPIs()
 
     function SMODS.GameObject:__call(o)
         o = o or {}
+        assert(o.mod == nil)
         o.mod = SMODS.current_mod
         setmetatable(o, self)
         for _, v in ipairs(o.required_params or {}) do
             assert(not (o[v] == nil), ('Missing required parameter for %s declaration: %s'):format(o.set, v))
         end
+        if o:check_duplicate_register() then return end
         -- also updates o.prefix_config
         SMODS.add_prefixes(self, o)
-        if o:check_duplicate_register() then return end
         if o:check_duplicate_key() then return end
         o:register()
         return o
@@ -148,11 +149,11 @@ function loadAPIs()
 
     --- Takes control of vanilla objects. Child class must implement get_obj for this to function.
     function SMODS.GameObject:take_ownership(key, obj, silent)
-        obj.key = key
-        SMODS.add_prefixes(self, obj, true)
-        print(tprint(obj))
-        key = obj.key
         if self.check_duplicate_register(obj) then return end
+        obj.key = key
+        assert(obj.mod == nil)
+        SMODS.add_prefixes(self, obj, true)
+        key = obj.key
         local o = self.obj_table[key] or (self.get_obj and self:get_obj(key))
         if not o then
             sendWarnMessage(

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -47,7 +47,7 @@ function loadAPIs()
         end
     end
 
-    function SMODS.add_prefixes(cls, obj, from_take_ownership)
+    function SMODS.add_prefixes(cls, obj)
         if obj.prefix_config == false then return end
         -- keep class defaults for unmodified keys in prefix_config
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
@@ -57,10 +57,8 @@ function loadAPIs()
         local key_cfg = obj.prefix_config.key
         if key_cfg ~= false then
             if type(key_cfg) ~= 'table' then key_cfg = {} end
-            if not from_take_ownership then
-                if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
-                SMODS.modify_key(obj, obj.mod and obj.mod.prefix, key_cfg.mod)
-            end
+            if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
+            SMODS.modify_key(obj, obj.mod and obj.mod.prefix, key_cfg.mod)
             SMODS.modify_key(obj, cls.class_prefix, key_cfg.class)
         end
         local atlas_cfg = obj.prefix_config.atlas
@@ -152,7 +150,7 @@ function loadAPIs()
         if self.check_duplicate_register(obj) then return end
         obj.key = key
         assert(obj.mod == nil)
-        SMODS.add_prefixes(self, obj, true)
+        SMODS.add_prefixes(self, obj)
         key = obj.key
         local o = self.obj_table[key] or (self.get_obj and self:get_obj(key))
         if not o then

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -40,7 +40,7 @@ function loadAPIs()
         -- condition == nil counts as true
         if condition ~= false and obj[key] and prefix then
             if string.sub(obj[key], 1, #prefix + 1) == prefix..'_' then
-                sendWarnMessage(("Attempted to prefix field %s on object %s, already prefixed"):format(key, obj.key), obj.set)
+                sendWarnMessage(("Attempted to prefix field %s=%s on object %s, already prefixed"):format(key, obj[key], obj.key), obj.set)
                 return
             end
             obj[key] = prefix .. '_' .. obj[key]

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -49,11 +49,16 @@ function loadAPIs()
 
     function SMODS.add_prefixes(cls, obj, from_take_ownership)
         if obj.prefix_config == false then return end
+        obj.prefix_config = obj.prefix_config or {}
+        if obj.raw_key then
+            sendWarnMessage(([[The field `raw_key` on %s is deprecated.
+Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.set)
+            obj.prefix_config.key = false
+        end
         -- keep class defaults for unmodified keys in prefix_config
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
         local mod = SMODS.current_mod
         obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, mod and mod.prefix_config)
-        obj.prefix_config = obj.prefix_config or {}
         obj.original_key = obj.key
         local key_cfg = obj.prefix_config.key
         if key_cfg ~= false then

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -557,10 +557,10 @@ function loadAPIs()
     end
 
     --Register vanilla stakes
+    G.P_STAKES = {}
     SMODS.Stake {
         name = "White Stake",
-        key = "stake_white",
-        prefix_config = { key = false },
+        key = "white",
         unlocked_stake = "red",
         unlocked = true,
         applied_stakes = {},
@@ -571,8 +571,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Red Stake",
-        key = "stake_red",
-        prefix_config = { key = false },
+        key = "red",
         unlocked_stake = "green",
         applied_stakes = { "white" },
         pos = { x = 1, y = 0 },
@@ -586,8 +585,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Green Stake",
-        key = "stake_green",
-        prefix_config = { key = false },
+        key = "green",
         unlocked_stake = "black",
         applied_stakes = { "red" },
         pos = { x = 2, y = 0 },
@@ -600,8 +598,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Black Stake",
-        key = "stake_black",
-        prefix_config = { key = false },
+        key = "black",
         unlocked_stake = "blue",
         applied_stakes = { "green" },
         pos = { x = 4, y = 0 },
@@ -614,8 +611,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Blue Stake",
-        key = "stake_blue",
-        prefix_config = { key = false },
+        key = "blue",
         unlocked_stake = "purple",
         applied_stakes = { "black" },
         pos = { x = 3, y = 0 },
@@ -628,8 +624,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Purple Stake",
-        key = "stake_purple",
-        prefix_config = { key = false },
+        key = "purple",
         unlocked_stake = "orange",
         applied_stakes = { "blue" },
         pos = { x = 0, y = 1 },
@@ -642,8 +637,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Orange Stake",
-        key = "stake_orange",
-        prefix_config = { key = false },
+        key = "orange",
         unlocked_stake = "gold",
         applied_stakes = { "purple" },
         pos = { x = 1, y = 1 },
@@ -656,8 +650,7 @@ function loadAPIs()
     }
     SMODS.Stake {
         name = "Gold Stake",
-        key = "stake_gold",
-        prefix_config = { key = false },
+        key = "gold",
         applied_stakes = { "orange" },
         pos = { x = 2, y = 1 },
         sticker_pos = { x = 3, y = 1 },

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -46,7 +46,7 @@ function loadAPIs()
             if type(key_cfg ~= 'table') then key_cfg = {} end
             self:modify_key(self.class_prefix, key_cfg.class)
             self:modify_key(self.mod and self.mod.prefix, key_cfg.mod)
-            self:modify_key(self.type and self.type:lower(), not not self.palette and key_cfg.type)
+            if self.set == 'Palette' then self:modify_key(self.type and self.type:lower(), key_cfg.type) end
         end
         local atlas_cfg = self.prefix_config.atlas
         if atlas_cfg ~= false then
@@ -448,7 +448,7 @@ function loadAPIs()
     SMODS.Stake = SMODS.GameObject:extend {
         obj_table = SMODS.Stakes,
         obj_buffer = {},
-        prefix = 'stake',
+        class_prefix = 'stake',
         unlocked = false,
         set = 'Stake',
         atlas = 'chips',
@@ -960,7 +960,7 @@ function loadAPIs()
         config = {},
         set = 'Joker',
         atlas = 'Joker',
-        prefix = 'j',
+        class_prefix = 'j',
         required_params = {
             'key',
         },
@@ -989,7 +989,7 @@ function loadAPIs()
         legendaries = {},
         cost = 3,
         config = {},
-        prefix = 'c',
+        class_prefix = 'c',
         required_params = {
             'set',
             'key',
@@ -1046,7 +1046,7 @@ function loadAPIs()
         available = true,
         pos = { x = 0, y = 0 },
         config = {},
-        prefix = 'v',
+        class_prefix = 'v',
         required_params = {
             'key',
         }
@@ -1064,7 +1064,7 @@ function loadAPIs()
         pos = { x = 0, y = 0 },
         config = {},
         stake = 1,
-        prefix = 'b',
+        class_prefix = 'b',
         required_params = {
             'key',
         },
@@ -1098,7 +1098,7 @@ function loadAPIs()
         required_params = {
             'key',
         },
-        prefix = 'p',
+        class_prefix = 'p',
         set = "Booster",
         atlas = "Booster",
         pos = {x = 0, y = 0},
@@ -1255,7 +1255,7 @@ function loadAPIs()
     SMODS.Blind = SMODS.GameObject:extend {
         obj_table = SMODS.Blinds,
         obj_buffer = {},
-        prefix = 'bl',
+        class_prefix = 'bl',
         debuff = {},
         vars = {},
         dollars = 5,
@@ -1316,7 +1316,7 @@ function loadAPIs()
         -- a badge, so badge_to_key, maybe?
         reverse_lookup = {},
         set = 'Seal',
-        prefix = 's',
+        class_prefix = 's',
         atlas = 'centers',
         pos = { x = 0, y = 0 },
         discovered = false,
@@ -1941,7 +1941,7 @@ function loadAPIs()
         played = 0,
         played_this_round = 0,
         level = 1,
-        prefix = 'h',
+        class_prefix = 'h',
         set = 'PokerHand',
         process_loc_text = function(self)
             SMODS.process_loc_text(G.localization.misc.poker_hands, self.key, self.loc_txt, 'name')
@@ -1994,7 +1994,7 @@ function loadAPIs()
         vouchers = {},
         restrictions = { banned_cards = {}, banned_tags = {}, banned_other = {} },
         unlocked = function(self) return true end,
-        prefix = 'c',
+        class_prefix = 'c',
         process_loc_text = function(self)
             SMODS.process_loc_text(G.localization.misc.challenge_names, self.key, self.loc_txt)
         end,
@@ -2054,7 +2054,7 @@ function loadAPIs()
         discovered = false,
         min_ante = nil,
         atlas = 'tags',
-        prefix = 'tag',
+        class_prefix = 'tag',
         set = 'Tag',
         pos = { x = 0, y = 0 },
         config = {},
@@ -2105,7 +2105,7 @@ function loadAPIs()
         required_params = {
             'key',
         },
-        prefix = 'st',
+        class_prefix = 'st',
         rate = 0.3,
         atlas = 'stickers',
         pos = { x = 0, y = 0 },
@@ -2134,7 +2134,7 @@ function loadAPIs()
         obj_buffer = {},
         obj_table = {},
         set = 'Payout Argument',
-        prefix = 'p',
+        class_prefix = 'p',
         required_params = {
             'key'
         },
@@ -2151,7 +2151,7 @@ function loadAPIs()
 
     SMODS.Enhancement = SMODS.Center:extend {
         set = 'Enhanced',
-        prefix = 'm',
+        class_prefix = 'm',
         atlas = 'centers',
         pos = { x = 0, y = 0 },
         required_params = {
@@ -2281,7 +2281,7 @@ function loadAPIs()
         -- atlas only matters for displaying editions in the collection
         atlas = 'Joker',
         pos = { x = 0, y = 0 },
-        prefix = 'e',
+        class_prefix = 'e',
         discovered = false,
         unlocked = true,
         apply_to_float = false,
@@ -2441,7 +2441,7 @@ function loadAPIs()
             'name'
         },
         set = 'Palette',
-        prefix = 'pal',
+        class_prefix = 'pal',
         inject = function(self)
             if not G.P_CENTER_POOLS[self.type] and self.type ~= "Suits" then return end
             if not SMODS.Palettes[self.type] then
@@ -2608,7 +2608,7 @@ function loadAPIs()
             'action',
         },
         set = 'Keybind',
-        prefix = 'keybind',
+        class_prefix = 'keybind',
 
         inject = function(_) end
     }

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -36,7 +36,7 @@ function loadAPIs()
     function SMODS.GameObject:modify_key(prefix, condition, key)
         key = key or 'key'
         if condition ~= false and self[key] and prefix then
-            self[key] = self[key] .. '_' .. prefix
+            self[key] = prefix .. '_' .. self[key]
         end
     end
 
@@ -49,15 +49,15 @@ function loadAPIs()
         local key_cfg = self.prefix_config.key
         if key_cfg ~= false then
             if type(key_cfg ~= 'table') then key_cfg = {} end
-            self:modify_key(self.class_prefix, key_cfg.class)
-            self:modify_key(self.mod and self.mod.prefix, key_cfg.mod)
             if self.set == 'Palette' then self:modify_key(self.type and self.type:lower(), key_cfg.type) end
+            self:modify_key(self.mod and self.mod.prefix, key_cfg.mod)
+            self:modify_key(self.class_prefix, key_cfg.class)
         end
         local atlas_cfg = self.prefix_config.atlas
         if atlas_cfg ~= false then
             if type(atlas_cfg ~= 'table') then atlas_cfg = {} end
             for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
-                self:modify_key(self.mod and self.mod.prefix, atlas_cfg[v], v)
+                if rawget(self, v) then self:modify_key(self.mod and self.mod.prefix, atlas_cfg[v], v) end
             end
         end
         local shader_cfg = self.prefix_config.shader
@@ -2488,13 +2488,13 @@ function loadAPIs()
     end
 
     for k, v in pairs(G.P_CENTER_POOLS.Tarot) do
-        SMODS.Consumable:take_ownership(v.key, { atlas = "Tarot" })
+        SMODS.Consumable:take_ownership(v.key, { atlas = "Tarot", prefix_config = { atlas = false } })
     end
     for _, v in pairs(G.P_CENTER_POOLS.Planet) do
-        SMODS.Consumable:take_ownership(v.key, { atlas = "Planet" })
+        SMODS.Consumable:take_ownership(v.key, { atlas = "Planet", prefix_config = { atlas = false } })
     end
     for _, v in pairs(G.P_CENTER_POOLS.Spectral) do
-        SMODS.Consumable:take_ownership(v.key, { atlas = "Spectral" })
+        SMODS.Consumable:take_ownership(v.key, { atlas = "Spectral", prefix_config = { atlas = false } })
     end
     SMODS.Atlas({
         key = "Planet",

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -26,9 +26,10 @@ function loadAPIs()
         for _, v in ipairs(o.required_params or {}) do
             assert(not (o[v] == nil), ('Missing required parameter for %s declaration: %s'):format(o.set, v))
         end
-        -- keep class defaults for unmodified keys in prefix_config
-        SMODS.merge_defaults(o.prefix_config, self.prefix_config)
-        SMODS.add_prefixes(o)
+        -- also updates o.prefix_config
+        SMODS.add_prefixes(self, o)
+        if o:check_duplicate_register() then return end
+        if o:check_duplicate_key() then return end
         o:register()
         return o
     end
@@ -37,13 +38,19 @@ function loadAPIs()
         key = key or 'key'
         -- condition == nil counts as true
         if condition ~= false and obj[key] and prefix then
+            if string.sub(obj[key], 1, #prefix + 1) == prefix..'_' then
+                sendWarnMessage(("Attempted to prefix field %s on object %s, already prefixed"):format(key, obj.key), obj.set)
+                return
+            end
             obj[key] = prefix .. '_' .. obj[key]
         end
     end
 
-    function SMODS.add_prefixes(obj)
+    function SMODS.add_prefixes(cls, obj)
         if obj.prefix_config == false then return end
-        SMODS.merge_defaults(obj.prefix_config, obj.mod and obj.mod.prefix_config)
+        -- keep class defaults for unmodified keys in prefix_config
+        obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, cls.prefix_config)
+        obj.prefix_config = SMODS.merge_defaults(obj.prefix_config, obj.mod and obj.mod.prefix_config)
         local mod = SMODS.current_mod
         obj.prefix_config = obj.prefix_config or {}
         obj.original_key = obj.key
@@ -52,7 +59,7 @@ function loadAPIs()
             if type(key_cfg) ~= 'table' then key_cfg = {} end
             if obj.set == 'Palette' then SMODS.modify_key(obj, obj.type and obj.type:lower(), key_cfg.type) end
             SMODS.modify_key(obj, mod and mod.prefix, key_cfg.mod)
-            SMODS.modify_key(obj, obj.class_prefix, key_cfg.class)
+            SMODS.modify_key(obj, cls.class_prefix, key_cfg.class)
         end
         local atlas_cfg = obj.prefix_config.atlas
         if atlas_cfg ~= false then
@@ -67,12 +74,26 @@ function loadAPIs()
         SMODS.modify_key(obj, mod and mod.prefix, card_key_cfg, 'card_key')
     end
 
-    function SMODS.GameObject:register()
+    function SMODS.GameObject:check_duplicate_register()
         if self.registered then
             sendWarnMessage(('Detected duplicate register call on object %s'):format(self.key), self.set)
-            return
+            return true
         end
-        if self:check_dependencies() and not self.obj_table[self.key] then
+        return false
+    end
+
+    -- Checked on __call but not take_ownership. For take_ownership, the key must exist
+    function SMODS.GameObject:check_duplicate_key()
+        if self.obj_table[self.key] or (self.get_obj and self:get_obj(self.key)) then
+            sendWarnMessage(('Object %s has the same key as an existing object, not registering.'):format(self.key), self.set)
+            sendWarnMessage('If you want to modify an existing object, use take_ownership()')
+            return true
+        end
+        return false
+    end
+
+    function SMODS.GameObject:register()
+        if self:check_dependencies() then
             self.obj_table[self.key] = self
             self.obj_buffer[#self.obj_buffer + 1] = self.key
             self.registered = true
@@ -126,29 +147,25 @@ function loadAPIs()
 
     --- Takes control of vanilla objects. Child class must implement get_obj for this to function.
     function SMODS.GameObject:take_ownership(key, obj, silent)
-        SMODS.merge_defaults(obj.prefix_config, self.prefix_config)
-        local conf = obj.prefix_config or self.prefix_config
-        local no_class_prefix = not self.class_prefix or
-            conf == false or
-            (conf and (conf.key == false)) or
-            conf and conf.key and (conf.key.class == false)
-        key = (no_class_prefix or key:sub(1, #self.class_prefix + 1) == self.class_prefix .. '_') and key or
-            ('%s_%s'):format(self.class_prefix, key)
-        local o = self.obj_table[key] or self:get_obj(key)
+        obj.key = key
+        SMODS.add_prefixes(self, obj)
+        print(tprint(obj))
+        key = obj.key
+        if self.check_duplicate_register(obj) then return end
+        local o = self.obj_table[key] or (self.get_obj and self:get_obj(key))
         if not o then
             sendWarnMessage(
-                ('Cannot take ownership of %s: Does not exist.'):format(key),
-                self.set
+                ('Cannot take ownership of %s: Does not exist.'):format(key), self.set
             )
             return
         end
-        obj.prefix_config = conf or {}
-        obj.prefix_config.key = false
-        SMODS.add_prefixes(obj)
         local original_has_loc = o.taken_ownership and (o.loc_txt or o.loc_vars or (o.generate_ui ~= self.generate_ui))
         local is_loc_modified = obj.loc_txt or obj.loc_vars or obj.generate_ui
         if not original_has_loc and not is_loc_modified then obj.generate_ui = 0 end
         if is_loc_modified and o.generate_ui == 0 then obj.generate_ui = obj.generate_ui or self.generate_ui end
+        -- TODO
+        -- it's unclear how much we should modify `obj` on a failed take_ownership call.
+        -- do we make sure the metatable is set early, or wait until the end?
         setmetatable(o, self)
         if o.mod then
             o.dependencies = o.dependencies or {}
@@ -156,7 +173,6 @@ function loadAPIs()
         else
             o.mod = SMODS.current_mod
             if silent then o.no_main_mod_badge = true end
-            o.key = key
             o.rarity_original = o.rarity
         end
         for k, v in pairs(obj) do o[k] = v end

--- a/core/utils.lua
+++ b/core/utils.lua
@@ -392,7 +392,9 @@ end
 function SMODS.merge_defaults(t, defaults)
     if not (t and defaults) then return end
     for k, v in pairs(defaults) do
-        t[k] = t[k] or v
+        if t[k] == nil then
+            t[k] = v
+        end
     end
 end
 

--- a/core/utils.lua
+++ b/core/utils.lua
@@ -388,14 +388,28 @@ function serialize_string(s)
 	return string.format("%q", s)
 end
 
--- fill in only the values from t2 that don't exist in t1
+-- Starting with `t`, insert any key-value pairs from `defaults` that don't already
+-- exist in `t` into `t`. Modifies `t`.
+-- Returns `t`, the result of the merge.
+--
+-- `nil` inputs count as {}; `false` inputs count as a table where
+-- every possible key maps to `false`. Therefore,
+-- * `t == nil` is weak and falls back to `defaults`
+-- * `t == false` explicitly ignores `defaults`
+-- (This function might not return a table, due to the above)
 function SMODS.merge_defaults(t, defaults)
-    if not (t and defaults) then return end
+    if t == false then return false end
+    if defaults == false then return false end
+
+    -- Add in the keys from `defaults`, returning a table
+    if defaults == nil then return t end
+    if t == nil then t = {} end
     for k, v in pairs(defaults) do
         if t[k] == nil then
             t[k] = v
         end
     end
+    return t
 end
 
 --#region palettes

--- a/core/utils.lua
+++ b/core/utils.lua
@@ -388,6 +388,14 @@ function serialize_string(s)
 	return string.format("%q", s)
 end
 
+-- fill in only the values from t2 that don't exist in t1
+function SMODS.merge_defaults(t, defaults)
+    if not (t and defaults) then return end
+    for k, v in pairs(defaults) do
+        t[k] = t[k] or v
+    end
+end
+
 --#region palettes
 G.SETTINGS.selected_colours = G.SETTINGS.selected_colours or {}
 G.PALETTE = {}

--- a/example_mods/Mods/NegateTexturePack/NegateTexturePack.lua
+++ b/example_mods/Mods/NegateTexturePack/NegateTexturePack.lua
@@ -11,9 +11,9 @@
 
 sendDebugMessage("Launching Negate Texture Pack!")
 
-SMODS.Atlas{key = "Joker", path = "Jokers-negate.png", px = 71, py = 95, raw_key = true}
-SMODS.Atlas{key = "Booster", path = "boosters-negate.png", px = 71, py = 95, raw_key = true}
-SMODS.Atlas{key = "blind_chips", path = "BlindChips-negate.png", px = 34, py = 34, raw_key = true, atlas_table = 'ANIMATION_ATLAS', frames = 21}
+SMODS.Atlas{key = "Joker", path = "Jokers-negate.png", px = 71, py = 95, prefix_config = { key = false } }
+SMODS.Atlas{key = "Booster", path = "boosters-negate.png", px = 71, py = 95, prefix_config = { key = false } }
+SMODS.Atlas{key = "blind_chips", path = "BlindChips-negate.png", px = 34, py = 34, prefix_config = { key = false }, atlas_table = 'ANIMATION_ATLAS', frames = 21}
 
 ----------------------------------------------
 ------------MOD CODE END----------------------

--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -207,9 +207,8 @@ function loadMods(modsDirectory)
                     end
                 
                     if mod.outdated then
-                        mod.omit_mod_prefix = true
-                    end
-                    if not mod.omit_mod_prefix then
+                        mod.prefix_config = { key = { mod = false }, atlas = false }
+                    else
                         mod.prefix = mod.prefix or (mod.id or ''):lower():sub(1, 4)
                     end
                     if mod.prefix and used_prefixes[mod.prefix] then


### PR DESCRIPTION
Allows for consistent configuration of key prefixing across all classes (#144).
Changes `card_key` for suits and ranks to comply with this. This field is no longer subject to automatic decollisioning and uses mod prefixes exclusively for this purpose.
TODO:
- ~~`SMODS.GameObject:take_ownership()` is currently a huge mess. We need to find a better way to integrate it into this new system.~~