### PR TITLE
feat: SMODS.load_file

### DIFF
--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -353,12 +353,27 @@ Stack Traceback
                 if string_sub(info.source, 1, 1) == "@" then
                     dumper:add_f("(%d) main chunk of file '%s' at line %d\r\n", level_to_show,
                         string_sub(info.source, 2), info.currentline)
-                elseif info.source and info.source:sub(1, 21) == "--- STEAMODDED HEADER" then
-                    local modName, modID = info.source:match("%-%-%- MOD_NAME: ([^\n]+)\n%-%-%- MOD_ID: ([^\n]+)")
-                    dumper:add_f("(%d) main chunk of mod %s (%s) at line %d\r\n", level_to_show, modName, modID,
-                        info.currentline)
+                elseif info.source and info.source:sub(1, 1) == "=" then
+                    local str = info.source:sub(3, -2)
+                    local props = {}
+                    -- Split by space
+                    for v in string.gmatch(str, "[^%s]+") do
+                        table.insert(props, v)
+                    end
+                    local source = table.remove(props, 1)
+                    if source == "love" then
+                        dumper:add_f("(%d) main chunk of Love2D file '%s' at line %d\r\n", level_to_show,
+                            table.concat(props, " "):sub(2, -2), info.currentline)
+                    elseif source == "SMODS" then
+                        local modID = table.remove(props, 1)
+                        local fileName = table.concat(props, " ")
+                        dumper:add_f("(%d) main chunk of file '%s' at line %d (from mod with id %s)\r\n", level_to_show,
+                            fileName:sub(2, -2), info.currentline, modID)
+                    else
+                        dumper:add_f("(%d) main chunk of %s at line %d\r\n", level_to_show, info.source, info.currentline)
+                    end
                 else
-                    dumper:add_f("(%d) main chunk of %s at line %d\r\n", level_to_show, info.short_src, info.currentline)
+                    dumper:add_f("(%d) main chunk of %s at line %d\r\n", level_to_show, info.source, info.currentline)
                 end
             elseif info.what == "C" then
                 -- print(info.namewhat, info.name)

--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -388,6 +388,7 @@ function initSteamodded()
     loadAPIs()
     boot_print_stage("Loading Mods")
     loadMods(SMODS.MODS_DIR)
+    SMODS.current_mod = nil
     initializeModUIFunctions()
     boot_print_stage("Injecting Items")
     SMODS.injectItems()
@@ -432,6 +433,32 @@ function boot_timer(_label, _next, progress)
 
     G.ARGS.bt = G.ARGS.bt or love.timer.getTime()
     G.ARGS.bt = love.timer.getTime()
+end
+
+function SMODS.load_file(path, id)
+    if not path or path == "" then
+        error("No path was provided to load.")
+    end
+    local mod
+    if not id then
+        if not SMODS.current_mod then
+            error("No ID was provided! Usage without an ID is only available when file is first loaded.")
+        end
+        mod = SMODS.current_mod
+    else 
+        mod = SMODS.Mods[id]
+    end
+    if not mod then
+        error("Mod not found. Ensure you are passing the correct ID.")
+    end 
+    local file_path = mod.path .. path
+    print(file_path)
+    local file_content, err = NFS.read(file_path)
+    if not file_content then return  nil, "Error reading file '" .. path .. "' for mod with ID '" .. mod.id .. "': " .. err end
+    print(file_content)
+    local chunk, err = load(file_content, "=[SMODS " .. mod.id .. ' "' .. path .. '"]')
+    if not chunk then return nil, "Error processing file '" .. path .. "' for mod with ID '" .. mod.id .. "': " .. err end
+    return chunk
 end
 
 ----------------------------------------------

--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -452,10 +452,8 @@ function SMODS.load_file(path, id)
         error("Mod not found. Ensure you are passing the correct ID.")
     end 
     local file_path = mod.path .. path
-    print(file_path)
     local file_content, err = NFS.read(file_path)
     if not file_content then return  nil, "Error reading file '" .. path .. "' for mod with ID '" .. mod.id .. "': " .. err end
-    print(file_content)
     local chunk, err = load(file_content, "=[SMODS " .. mod.id .. ' "' .. path .. '"]')
     if not chunk then return nil, "Error processing file '" .. path .. "' for mod with ID '" .. mod.id .. "': " .. err end
     return chunk


### PR DESCRIPTION
Add's a new method, `SMODS.load_file(path, id)`. This method take's in a path, relative to the mod's main directory, and optinally the mod id (will use SMODS.current_mod if not. Just got thinking should I require the mod object instead of the id?). It then reads the file and loads it. Return type is the same as [love.filesystem.load](https://love2d.org/wiki/love.filesystem.load) and [loadfile](https://www.lua.org/manual/5.1/manual.html#pdf-loadfile).

Example:
`Main.lua`
```lua
--- STEAMODDED HEADER
--- MOD_NAME: Load Test
--- MOD_ID: LoadTest
--- MOD_AUTHOR: [WilsontheWolf]
--- MOD_DESCRIPTION: Testing for new api
----------------------------------------------
------------MOD CODE -------------------------
local mod = SMODS.current_mod;

assert(SMODS.load_file("Loaded.lua"))()
----------------------------------------------
------------MOD CODE END----------------------
```
`Loaded.lua`
```lua
print("Hi mom")

-- error("Test") -- Uncomment me to see that my filename is properly shown in the crash log
```


- Also fixes a parsing issue in StackTracePlus, which I encountered testing if this worked.
- Also nil's current_mod after loading mods, which prevents mods from accidentally loading files from another mod's directory.