### PR TITLE
feat: improve crash handler reliability, and load sooner

### DIFF
--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -487,7 +487,7 @@ function getDebugInfoForCrash()
             end
         end
         for k, v in ipairs(enabled_mods) do
-            info = info .. "\n    " .. k .. ": " .. v.name .. " by " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
+            info = info .. "\n    " .. k .. ": " .. v.name .. " by " .. table.concat(v.author, ", ") .. " [ID: " .. v.id ..
                        (v.priority ~= 0 and (", Priority: " .. v.priority) or "") ..
                        (v.version and v.version ~= '0.0.0' and (", Version: " .. v.version) or "") .. "]"
             local debugInfo = v.debug_info

--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -482,11 +482,14 @@ function getDebugInfoForCrash()
         info = info .. "\nSteamodded Mods:"
         local enabled_mods = {}
         for _, v in ipairs(SMODS.mod_list) do
-            if v.can_load then table.insert(enabled_mods, v) end
+            if v.can_load then
+                table.insert(enabled_mods, v)
+            end
         end
         for k, v in ipairs(enabled_mods) do
             info = info .. "\n    " .. k .. ": " .. v.name .. " by " .. concatAuthors(v.author) .. " [ID: " .. v.id ..
-                       (v.priority ~= 0 and (", Priority: " .. v.priority) or "") .. (v.version and v.version ~= '0.0.0' and (", Version: " .. v.version) or "") .. "]"
+                       (v.priority ~= 0 and (", Priority: " .. v.priority) or "") ..
+                       (v.version and v.version ~= '0.0.0' and (", Version: " .. v.version) or "") .. "]"
             local debugInfo = v.debug_info
             if debugInfo then
                 if type(debugInfo) == "string" then
@@ -520,6 +523,17 @@ function injectStackTrace()
     -- Modifed from https://love2d.org/wiki/love.errorhandler
     function love.errorhandler(msg)
         msg = tostring(msg)
+
+        if not sendErrorMessage then
+            function sendErrorMessage(msg)
+                print(msg)
+            end
+        end
+        if not sendInfoMessage then
+            function sendInfoMessage(msg)
+                print(msg)
+            end
+        end
 
         sendErrorMessage("Oops! The game crashed\n" .. STP.stacktrace(msg), 'StackTrace')
 
@@ -556,7 +570,11 @@ function injectStackTrace()
         love.graphics.reset()
         local font = love.graphics.setNewFont("resources/fonts/m6x11plus.ttf", 20)
 
-        love.graphics.clear(G.C.BLACK)
+        local background = {0, 0, 1}
+        if G and G.C and G.C.BLACK then
+            background = G.C.BLACK
+        end
+        love.graphics.clear(background)
         love.graphics.origin()
 
         local trace = STP.stacktrace("", 3)
@@ -639,18 +657,19 @@ function injectStackTrace()
             if not love.graphics.isActive() then
                 return
             end
-            love.graphics.clear(G.C.BLACK)
+            love.graphics.clear(background)
             calcEndHeight()
             love.graphics.printf(p, pos, pos - scrollOffset, love.graphics.getWidth() - pos * 2)
             if scrollOffset ~= endHeight then
-            love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2), love.graphics.getHeight() - arrowSize,
-                love.graphics.getWidth() - (pos / 2) + arrowSize, love.graphics.getHeight() - (arrowSize * 2),
-                love.graphics.getWidth() - (pos / 2) - arrowSize, love.graphics.getHeight() - (arrowSize * 2))
+                love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2),
+                    love.graphics.getHeight() - arrowSize, love.graphics.getWidth() - (pos / 2) + arrowSize,
+                    love.graphics.getHeight() - (arrowSize * 2), love.graphics.getWidth() - (pos / 2) - arrowSize,
+                    love.graphics.getHeight() - (arrowSize * 2))
             end
             if scrollOffset ~= 0 then
-            love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2), arrowSize,
-                love.graphics.getWidth() - (pos / 2) + arrowSize, arrowSize * 2,
-                love.graphics.getWidth() - (pos / 2) - arrowSize, arrowSize * 2)
+                love.graphics.polygon("fill", love.graphics.getWidth() - (pos / 2), arrowSize,
+                    love.graphics.getWidth() - (pos / 2) + arrowSize, arrowSize * 2,
+                    love.graphics.getWidth() - (pos / 2) - arrowSize, arrowSize * 2)
             end
             love.graphics.present()
         end
@@ -664,26 +683,28 @@ function injectStackTrace()
             p = p .. "\nCopied to clipboard!"
         end
 
-        p = p .. "\n\nPress R to restart the game"
+        p = p .. "\n\nPress ESC to exit\nPress R to restart the game (currently breaks lovely)"
         if love.system then
             p = p .. "\nPress Ctrl+C or tap to copy this error"
         end
 
-        -- Kill threads (makes restarting possible)
-        if G.SOUND_MANAGER and G.SOUND_MANAGER.channel then
-            G.SOUND_MANAGER.channel:push({
-                type = 'kill'
-            })
-        end
-        if G.SAVE_MANAGER and G.SAVE_MANAGER.channel then
-            G.SAVE_MANAGER.channel:push({
-                type = 'kill'
-            })
-        end
-        if G.HTTP_MANAGER and G.HTTP_MANAGER.channel then
-            G.HTTP_MANAGER.channel:push({
-                type = 'kill'
-            })
+        if G then
+            -- Kill threads (makes restarting possible)
+            if G.SOUND_MANAGER and G.SOUND_MANAGER.channel then
+                G.SOUND_MANAGER.channel:push({
+                    type = 'kill'
+                })
+            end
+            if G.SAVE_MANAGER and G.SAVE_MANAGER.channel then
+                G.SAVE_MANAGER.channel:push({
+                    type = 'kill'
+                })
+            end
+            if G.HTTP_MANAGER and G.HTTP_MANAGER.channel then
+                G.HTTP_MANAGER.channel:push({
+                    type = 'kill'
+                })
+            end
         end
 
         return function()

--- a/lovely/core.toml
+++ b/lovely/core.toml
@@ -17,7 +17,6 @@ target = "main.lua"
 position = "append"
 sources = [
 	"core/core.lua",
-	"core/StackTracePlus.lua",
 	"core/utils.lua",
 	"core/overrides.lua",
 	"core/game_object.lua",

--- a/lovely/crash_handler.toml
+++ b/lovely/crash_handler.toml
@@ -5,7 +5,7 @@ priority = 0
 
 [[patches]]
 [patches.pattern]
-target = "game.lua"
+target = "main.lua"
 pattern = "function love.errhand(msg)"
 position = "at"
 payload = "if false then"

--- a/lovely/crash_handler.toml
+++ b/lovely/crash_handler.toml
@@ -1,0 +1,20 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "function love.errhand(msg)"
+position = "at"
+payload = "if false then"
+match_indent = true
+
+[[patches]]
+[patches.copy]
+target = "main.lua"
+position = "prepend"
+sources = [
+	"core/StackTracePlus.lua",
+]


### PR DESCRIPTION
This PR makes some improvements to the crash handler. Most notably:
- Improve reliability, but not assuming some things are always avaible.
- Injecting the crash handler at the beginning of the main lua file, to catch more errors (and completly disabling the built in one)
- Adds a note that esc exits the game (as the game can get stuck in fullscreen if it crashes too early)
- Adds a note that restarting the game breaks lovely (hopefully we can get this fixed soon)

As an aside, you can change the target of the copy patch to `'=[love "wrap_Event.lua"]'` to hook an internal love function, and get the handler loaded before love even try's loading the main file. This allows it to catch syntax errors, but this does seem kinda hacky, and lovely throws an error trying to dump that file, so idk if we want to do that.