### PR TITLE
Edition improvements, number formatting fixes, small performance fix and UI tab triangles fix

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -909,7 +909,15 @@ function Card:set_edition(edition, immediate, silent)
 	self.edition.type = edition_type
 	self.edition.key = 'e_' .. edition_type
 
-	for k, v in pairs(G.P_CENTERS['e_' .. edition_type].config) do
+	local p_edition = G.P_CENTERS['e_' .. edition_type]
+	if p_edition.override_shape then
+		self.edition.override_shape = p_edition.shader
+	end
+	if p_edition.no_shadow then
+		self.edition.no_shadow = true
+	end
+
+	for k, v in pairs(p_edition.config) do
 		if type(v) == 'table' then
 			self.edition[k] = copy_table(v)
 		else

--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -846,6 +846,29 @@ G.FUNCS.your_collection_editions_page = function(args)
 	end
 end
 
+-- Init custom card parameters.
+local card_init = Card.init
+function Card:init(X, Y, W, H, card, center, params)
+	card_init(self, X, Y, W, H, card, center, params)
+
+	-- This table contains object keys for layers (e.g. edition) 
+	-- that dont want base layer to be drawn.
+	-- When layer is removed, layer's value should be set to nil.
+	self.ignore_base_shader = self.ignore_base_shader or {}
+	-- This table contains object keys for layers (e.g. edition) 
+	-- that dont want shadow to be drawn.
+	-- When layer is removed, layer's value should be set to nil.
+	self.ignore_shadow = self.ignore_shadow or {}
+end
+
+function Card:should_draw_base_shader()
+	return not next(self.ignore_base_shader or {})
+end
+
+function Card:should_draw_shadow()
+	return not next(self.ignore_shadow or {})
+end
+
 -- self = pass the card
 -- edition =
 -- nil (removes edition)
@@ -864,6 +887,12 @@ function Card:set_edition(edition, immediate, silent)
 		elseif self.area == G.hand then
 			G.hand.config.card_limit = G.hand.config.card_limit - self.edition.card_limit
 		end
+	end
+
+	local old_edition = self.edition and self.edition.key
+	if old_edition then
+		self.ignore_base_shader[old_edition] = nil
+		self.ignore_shadow[old_edition] = nil
 	end
 
 	local edition_type = nil
@@ -910,11 +939,12 @@ function Card:set_edition(edition, immediate, silent)
 	self.edition.key = 'e_' .. edition_type
 
 	local p_edition = G.P_CENTERS['e_' .. edition_type]
-	if p_edition.override_shape then
-		self.edition.override_shape = p_edition.shader
+
+	if p_edition.override_base_shader then
+		self.ignore_base_shader[self.edition.key] = true
 	end
 	if p_edition.no_shadow then
-		self.edition.no_shadow = true
+		self.ignore_shadow[self.edition.key] = true
 	end
 
 	for k, v in pairs(p_edition.config) do

--- a/example_mods/Mods/EditionExamples/EditionExamples.lua
+++ b/example_mods/Mods/EditionExamples/EditionExamples.lua
@@ -336,6 +336,10 @@ SMODS.Edition({
             "and {X:mult,C:white}X#3#{} Mult"
         }
     },
+    -- Use this to send raw tilt amount and visual transform rotation.
+    -- This will (probably) not work well with existing shaders
+    -- send_raw_tilt = true,
+
     shader = "greyscale",
     discovered = true,
     unlocked = true,

--- a/example_mods/Mods/EditionExamples/EditionExamples.lua
+++ b/example_mods/Mods/EditionExamples/EditionExamples.lua
@@ -336,7 +336,7 @@ SMODS.Edition({
         }
     },
     no_shadow = true, -- This will stop shadow from being rendered under the card
-    override_shape = true, -- This will stop extra layer being rendered below the shader. Necessary for edition that modify shape of a card.
+    override_base_shader = true, -- This will stop extra layer being rendered below the shader. Necessary for edition that modify shape of a card.
     shader = "flipped",
     discovered = true,
     unlocked = true,

--- a/example_mods/Mods/EditionExamples/EditionExamples.lua
+++ b/example_mods/Mods/EditionExamples/EditionExamples.lua
@@ -336,9 +336,6 @@ SMODS.Edition({
             "and {X:mult,C:white}X#3#{} Mult"
         }
     },
-    -- Use this to send raw tilt amount and visual transform rotation.
-    -- This will (probably) not work well with existing shaders
-    -- send_raw_tilt = true,
 
     shader = "greyscale",
     discovered = true,

--- a/example_mods/Mods/EditionExamples/EditionExamples.lua
+++ b/example_mods/Mods/EditionExamples/EditionExamples.lua
@@ -2,7 +2,7 @@
 --- MOD_NAME: Edition Examples
 --- MOD_ID: EditionExamples
 --- PREFIX: edex
---- MOD_AUTHOR: [Eremel_]
+--- MOD_AUTHOR: [Eremel_, stupxd]
 --- MOD_DESCRIPTION: Adds editions that demonstrate Edition API.
 --- BADGE_COLOUR: 3FC7EB
 
@@ -316,7 +316,7 @@ SMODS.Back({
 })
 
 SMODS.Shader({key = 'anaglyphic', path = 'anaglyphic.fs'})
--- SMODS.Shader({key = 'flipped', path = 'flipped.fs'})
+SMODS.Shader({key = 'flipped', path = 'flipped.fs'})
 SMODS.Shader({key = 'fluorescent', path = 'fluorescent.fs'})
 -- SMODS.Shader({key = 'gilded', path = 'gilded.fs'})
 SMODS.Shader({key = 'greyscale', path = 'greyscale.fs'})
@@ -325,6 +325,30 @@ SMODS.Shader({key = 'greyscale', path = 'greyscale.fs'})
 -- SMODS.Shader({key = 'monochrome', path = 'monochrome.fs'})
 SMODS.Shader({key = 'overexposed', path = 'overexposed.fs'})
 -- SMODS.Shader({key = 'sepia', path = 'sepia.fs'})
+
+SMODS.Edition({
+    key = "flipped",
+    loc_txt = {
+        name = "Flipped",
+        label = "Flipped",
+        text = {
+            "nothin"
+        }
+    },
+    no_shadow = true, -- This will stop shadow from being rendered under the card
+    override_shape = true, -- This will stop extra layer being rendered below the shader. Necessary for edition that modify shape of a card.
+    shader = "flipped",
+    discovered = true,
+    unlocked = true,
+    config = { },
+    in_shop = true,
+    weight = 8,
+    extra_cost = 6,
+    apply_to_float = true,
+    loc_vars = function(self)
+        return { vars = {  } }
+    end
+})
 
 SMODS.Edition({
     key = "greyscale",

--- a/example_mods/Mods/EditionExamples/assets/shaders/anaglyphic.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/anaglyphic.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 anaglyphic;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/flipped.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/flipped.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 flipped;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/fluorescent.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/fluorescent.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 fluorescent;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/foil.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/foil.fs
@@ -5,7 +5,7 @@
 #endif
 
 
-// Card rotation
+// Look ionized.fs for explanation
 extern MY_HIGHP_OR_MEDIUMP vec2 foil;
 extern MY_HIGHP_OR_MEDIUMP number dissolve;
 extern MY_HIGHP_OR_MEDIUMP number time;

--- a/example_mods/Mods/EditionExamples/assets/shaders/gilded.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/gilded.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 gilded;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/greyscale.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/greyscale.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 greyscale;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
@@ -4,10 +4,17 @@
     #define PRECISION mediump
 #endif
 
-// change this variable name to your Edition's name
 // YOU MUST USE THIS VARIABLE IN THE vec4 effect AT LEAST ONCE
-// ^^ CRITICALLY IMPORTANT (IDK WHY) <- because compiler optimization
-// Card rotation
+
+// Values of this variable:
+// self.ARGS.send_to_shader[1] = math.min(self.VT.r*3, 1) + G.TIMERS.REAL/(28) + (self.juice and self.juice.r*20 or 0) + self.tilt_var.amt
+// self.ARGS.send_to_shader[2] = G.TIMERS.REAL
+// these default values suck and time makes no sense as we already get it below.
+
+// If you add `send_raw_tilt = true,` in your EDITION declaration, 
+// shader will receive these instead:
+// self.VT.r          -- Visible transform rotation
+// self.tilt_var.amt  -- Amount of tilt
 extern PRECISION vec2 ionized;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
@@ -4,6 +4,7 @@
     #define PRECISION mediump
 #endif
 
+// !! change this variable name to your Shader's name
 // YOU MUST USE THIS VARIABLE IN THE vec4 effect AT LEAST ONCE
 
 // Values of this variable:

--- a/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/ionized.fs
@@ -7,14 +7,8 @@
 // YOU MUST USE THIS VARIABLE IN THE vec4 effect AT LEAST ONCE
 
 // Values of this variable:
-// self.ARGS.send_to_shader[1] = math.min(self.VT.r*3, 1) + G.TIMERS.REAL/(28) + (self.juice and self.juice.r*20 or 0) + self.tilt_var.amt
+// self.ARGS.send_to_shader[1] = math.min(self.VT.r*3, 1) + (math.sin(G.TIMERS.REAL/28) + 1) + (self.juice and self.juice.r*20 or 0) + self.tilt_var.amt
 // self.ARGS.send_to_shader[2] = G.TIMERS.REAL
-// these default values suck and time makes no sense as we already get it below.
-
-// If you add `send_raw_tilt = true,` in your EDITION declaration, 
-// shader will receive these instead:
-// self.VT.r          -- Visible transform rotation
-// self.tilt_var.amt  -- Amount of tilt
 extern PRECISION vec2 ionized;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/laminated.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/laminated.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 laminated;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/monochrome.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/monochrome.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 monochrome;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/overexposed.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/overexposed.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 overexposed;
 
 extern PRECISION number dissolve;

--- a/example_mods/Mods/EditionExamples/assets/shaders/sepia.fs
+++ b/example_mods/Mods/EditionExamples/assets/shaders/sepia.fs
@@ -4,7 +4,7 @@
 	#define PRECISION mediump
 #endif
 
-// Card rotation
+// Look ionized.fs for explanation
 extern PRECISION vec2 sepia;
 
 extern PRECISION number dissolve;

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -92,10 +92,6 @@ payload = '''
 if self.edition then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
         if self.edition[v.key:sub(3)] then
-            if v.send_raw_tilt then
-                self.ARGS.send_to_shader[1] = self.VT.r
-                self.ARGS.send_to_shader[2] = self.tilt_var.amt
-            end
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)
             if self.children.front and self.ability.effect ~= 'Stone Card' and not self.config.center.replace_base_card then
                 self.children.front:draw_shader(v.shader, nil, self.ARGS.send_to_shader)
@@ -104,6 +100,17 @@ if self.edition then
     end
 end'''
 line_prepend = "$indent"
+
+# Limit ARGS.send_to_shader[1] to wiggle between 0 and 2 instead of growing infinitely
+# this makes shaders responsiveness on tilt reliable over time
+# Card:draw()
+[[patches]]
+[patches.regex]
+target = "card.lua"
+pattern = '''
+G\.TIMERS\.REAL/\(28\)'''
+position = "at"
+payload = '''math.sin(G.TIMERS.REAL/28) + 1'''
 
 # Inject shaders applying to floating sprites
 [[patches]]

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -97,7 +97,7 @@ target = "card.lua"
 pattern = '''
 self\.ability\.effect ~= 'Glass Card' and not self\.greyed'''
 position = "after"
-payload = ''' and not (self.edition and self.edition.no_shadow)'''
+payload = ''' and self:should_draw_shadow() '''
 
 # If shader modifies shape of card, this will stop "back" layer of the card being rendered.
 # Card:draw()
@@ -108,11 +108,8 @@ pattern = '''
 elseif not self.greyed then'''
 position = "before"
 payload = '''
-elseif self.edition and self.edition.override_shape then
-    self.children.center:draw_shader(self.edition.override_shape, nil, self.ARGS.send_to_shader)
-    if self.children.front and self.ability.effect ~= 'Stone Card' then
-        self.children.front:draw_shader(self.edition.override_shape, nil, self.ARGS.send_to_shader)
-    end
+elseif not self:should_draw_base_shader() then
+    -- Don't render base dissolve shader.
 '''
 match_indent = true
 
@@ -126,7 +123,7 @@ pattern = '''
 if self.ability.set == 'Booster' or self.ability.set == 'Spectral' then'''
 position = "at"
 payload = '''
-if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and not (self.edition and self.edition.override_shape) then'''
+if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and self:should_draw_base_shader() then'''
 match_indent = true
 
 # Inject shaders applying to cards
@@ -140,7 +137,7 @@ pattern = '''
 [\t ]*end'''
 position = "at"
 payload = '''
-if self.edition and not self.edition.override_shape then
+if self.edition then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
         if self.edition[v.key:sub(3)] then
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -124,7 +124,7 @@ match_indent = true
 target = "card.lua"
 pattern = '''
 if self.ability.set == 'Booster' or self.ability.set == 'Spectral' then'''
-position = "before"
+position = "at"
 payload = '''
 if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and not (self.edition and self.edition.override_shape) then'''
 match_indent = true
@@ -140,7 +140,7 @@ pattern = '''
 [\t ]*end'''
 position = "at"
 payload = '''
-if self.edition and not self.edition.dissolve_override then
+if self.edition and not self.edition.override_shape then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
         if self.edition[v.key:sub(3)] then
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -92,6 +92,10 @@ payload = '''
 if self.edition then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
         if self.edition[v.key:sub(3)] then
+            if v.send_raw_tilt then
+                self.ARGS.send_to_shader[1] = self.VT.r
+                self.ARGS.send_to_shader[2] = self.tilt_var.amt
+            end
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)
             if self.children.front and self.ability.effect ~= 'Stone Card' and not self.config.center.replace_base_card then
                 self.children.front:draw_shader(v.shader, nil, self.ARGS.send_to_shader)

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -78,6 +78,57 @@ for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
 	G.BADGE_COL[v.key:sub(3)] = v.badge_colour
 end'''
 
+# Limit ARGS.send_to_shader[1] to wiggle between 0 and 2 instead of growing infinitely
+# this makes shaders responsiveness on tilt reliable over time
+# Card:draw()
+[[patches]]
+[patches.regex]
+target = "card.lua"
+pattern = '''
+G\.TIMERS\.REAL/\(28\)'''
+position = "at"
+payload = '''math.sin(G.TIMERS.REAL/28) + 1'''
+
+# Allow editions to not draw shadow
+# Card:draw()
+[[patches]]
+[patches.regex]
+target = "card.lua"
+pattern = '''
+self\.ability\.effect ~= 'Glass Card' and not self\.greyed'''
+position = "after"
+payload = ''' and not (self.edition and self.edition.no_shadow)'''
+
+# If shader modifies shape of card, this will stop "back" layer of the card being rendered.
+# Card:draw()
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+elseif not self.greyed then'''
+position = "before"
+payload = '''
+elseif self.edition and self.edition.override_shape then
+    self.children.center:draw_shader(self.edition.override_shape, nil, self.ARGS.send_to_shader)
+    if self.children.front and self.ability.effect ~= 'Stone Card' then
+        self.children.front:draw_shader(self.edition.override_shape, nil, self.ARGS.send_to_shader)
+    end
+'''
+match_indent = true
+
+# If shader modifies shape of card, this will stop "back" layer of the card being rendered.
+# spectral cards and booster packs only.
+# Card:draw()
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.set == 'Booster' or self.ability.set == 'Spectral' then'''
+position = "before"
+payload = '''
+if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and not (self.edition and self.edition.override_shape) then'''
+match_indent = true
+
 # Inject shaders applying to cards
 # Card:draw()
 [[patches]]
@@ -89,7 +140,7 @@ pattern = '''
 [\t ]*end'''
 position = "at"
 payload = '''
-if self.edition then
+if self.edition and not self.edition.dissolve_override then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
         if self.edition[v.key:sub(3)] then
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)
@@ -100,17 +151,6 @@ if self.edition then
     end
 end'''
 line_prepend = "$indent"
-
-# Limit ARGS.send_to_shader[1] to wiggle between 0 and 2 instead of growing infinitely
-# this makes shaders responsiveness on tilt reliable over time
-# Card:draw()
-[[patches]]
-[patches.regex]
-target = "card.lua"
-pattern = '''
-G\.TIMERS\.REAL/\(28\)'''
-position = "at"
-payload = '''math.sin(G.TIMERS.REAL/28) + 1'''
 
 # Inject shaders applying to floating sprites
 [[patches]]

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -426,7 +426,7 @@ if num ~= math.floor(num) then
 else 
   formatted = string.format("%.0f", num)
 end
-return formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()'''
+return formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):gsub(",%-$", "-"):reverse()'''
 match_indent = true
 
 #

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -395,12 +395,38 @@ pattern = '''
 return string.format("%.3f",x/(10^fac))..'e'..fac'''
 position = "at"
 payload = '''
+if num == math.huge then
+    return "infinity"
+end
+
 local mantissa = round_number(x/(10^fac), 3)
 if mantissa >= 10 then
   mantissa = mantissa / 10
   fac = fac + 1
 end
 return string.format(fac >= 100 and "%.1fe%i" or fac >= 10 and "%.2fe%i" or "%.3fe%i", mantissa, fac)'''
+match_indent = true
+
+# Remove trailing zeroes
+# Fix 1.5 being formatted as 1.50
+## number_format
+[[patches]] 
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = '''
+return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()'''
+position = "at"
+payload = '''
+local formatted
+if num ~= math.floor(num) then
+  formatted = string.format(num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f", num)
+  if num < 10 and formatted:sub(-1) == "0" then
+    formatted = formatted:sub(1, -2)
+  end
+else 
+  formatted = string.format("%.0f", num)
+end
+return formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()'''
 match_indent = true
 
 #

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -382,52 +382,6 @@ position = "after"
 payload = "self.scale = self.config.scale_function and self.config.scale_function() or self.scale"
 match_indent = true
 
-#
-# Fix floating point error (1.000e92 instead of 10.000e91)
-# Lower precision with higher numbers
-#
-
-## number_format
-[[patches]] 
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = '''
-return string.format("%.3f",x/(10^fac))..'e'..fac'''
-position = "at"
-payload = '''
-if num == math.huge then
-    return "naneinf"
-end
-
-local mantissa = round_number(x/(10^fac), 3)
-if mantissa >= 10 then
-  mantissa = mantissa / 10
-  fac = fac + 1
-end
-return string.format(fac >= 100 and "%.1fe%i" or fac >= 10 and "%.2fe%i" or "%.3fe%i", mantissa, fac)'''
-match_indent = true
-
-# Remove trailing zeroes
-# Fix 1.5 being formatted as 1.50
-## number_format
-[[patches]] 
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = '''
-return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()'''
-position = "at"
-payload = '''
-local formatted
-if num ~= math.floor(num) then
-  formatted = string.format(num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f", num)
-  if num < 10 and formatted:sub(-1) == "0" then
-    formatted = formatted:sub(1, -2)
-  end
-else 
-  formatted = string.format("%.0f", num)
-end
-return formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):gsub(",%-$", "-"):reverse()'''
-match_indent = true
 
 #
 # Fix gold stake legendary infloop

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -442,3 +442,61 @@ pattern = '''if win_ante and (win_ante >= 8) then'''
 match_indent = true
 position = "at"
 payload = '''if win_ante and (win_ante >= 8) or (v.in_pool and type(v.in_pool) == 'function' and not v:in_pool()) then'''
+
+#
+# Fix G.GAME.blind:set_blind(nil, true, nil)
+# being called when not in blind.
+#
+
+# Card:add_to_deck
+# Card:remove_from_deck
+[[patches]]
+[patches.regex]
+target = "card.lua"
+pattern = 'if G\.GAME\.blind then'
+position = "at"
+payload = "if G.GAME.blind and G.GAME.blind.in_blind then"
+
+# Blind:set_blind
+[[patches]]
+[patches.pattern]
+target = "blind.lua"
+match_indent = true
+pattern = "if not reset then"
+position = "after"
+payload = '''
+    if blind then
+        self.in_blind = true
+    end'''
+
+# end_round()
+[[patches]]
+[patches.pattern]
+target = "functions/state_events.lua"
+pattern = "local game_over = true"
+position = "before"
+payload = "G.GAME.blind.in_blind = false"
+match_indent = true
+
+
+
+# Make sure new param is loaded
+[[patches]]
+[patches.pattern]
+target = "blind.lua"
+match_indent = true
+pattern = "function Blind:load(blindTable)"
+position = "after"
+payload = '''
+    self.in_blind = blindTable.in_blind'''
+
+# Make sure new param is saved
+[[patches]]
+[patches.pattern]
+target = "blind.lua"
+match_indent = true
+pattern = "local blindTable = {"
+position = "after"
+payload = '''
+    in_blind = self.in_blind,'''
+

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -396,7 +396,7 @@ return string.format("%.3f",x/(10^fac))..'e'..fac'''
 position = "at"
 payload = '''
 if num == math.huge then
-    return "infinity"
+    return "naneinf"
 end
 
 local mantissa = round_number(x/(10^fac), 3)

--- a/lovely/number_formatting.toml
+++ b/lovely/number_formatting.toml
@@ -145,7 +145,8 @@ if num ~= math.floor(num) and num < 100 then
   if formatted:sub(-1) == "0" then
     formatted = formatted:gsub("%.?0+$", "")
   end
-  if num < 0.01 then formatted = tostring(num) end
+  -- Return already to avoid comas being added
+  if num < 0.01 then return tostring(num) end
 else 
   formatted = string.format("%.0f", num)
 end

--- a/lovely/number_formatting.toml
+++ b/lovely/number_formatting.toml
@@ -94,7 +94,10 @@ payload = "scale_number(saved_game.GAME.round_scores.hand.amt, 0.8*scale, 100000
 target = "functions/misc_functions.lua"
 pattern = 'function number_format(num)'
 position = "at"
-payload = 'function number_format(num, e_switch_point)'
+payload = '''
+function number_format(num, e_switch_point)
+    local sign = (num >= 0 and "") or "-"
+    num = math.abs(num)'''
 match_indent = true
 
 [[patches]] 
@@ -103,6 +106,48 @@ target = "functions/misc_functions.lua"
 pattern = 'num >= G\.E_SWITCH_POINT'
 position = "at"
 payload = "num >= (e_switch_point or G.E_SWITCH_POINT)"
+
+# 1. Fix floating point error (1.000e92 instead of 10.000e91)
+# 2. Lower precision with higher numbers
+[[patches]] 
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = '''
+return string.format("%.3f",x/(10^fac))..'e'..fac'''
+position = "at"
+payload = '''
+if num == math.huge then
+    return sign.."naneinf"
+end
+
+local mantissa = round_number(x/(10^fac), 3)
+if mantissa >= 10 then
+  mantissa = mantissa / 10
+  fac = fac + 1
+end
+return sign..(string.format(fac >= 100 and "%.1fe%i" or fac >= 10 and "%.2fe%i" or "%.3fe%i", mantissa, fac))'''
+match_indent = true
+
+# Remove trailing zeroes
+# E.g. X1.5 being displayed as X1.50
+[[patches]] 
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = '''
+return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()'''
+position = "at"
+payload = '''
+local formatted
+if num ~= math.floor(num) and num < 100 then
+  formatted = string.format(num >= 10 and "%.1f" or "%.2f", num)
+  if formatted:sub(-1) == "0" then
+    formatted = formatted:gsub("%.?0+$", "")
+  end
+else 
+  formatted = string.format("%.0f", num)
+end
+return sign..(formatted:reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse())'''
+match_indent = true
 
 ## scale_number
 [[patches]] 
@@ -118,5 +163,5 @@ match_indent = true
 target = "functions/button_callbacks.lua"
 pattern = 'number >= G\.E_SWITCH_POINT'
 position = "at"
-payload = "number >= (e_switch_point or G.E_SWITCH_POINT)"
+payload = "math.abs(number) >= (e_switch_point or G.E_SWITCH_POINT)"
 

--- a/lovely/number_formatting.toml
+++ b/lovely/number_formatting.toml
@@ -96,6 +96,8 @@ pattern = 'function number_format(num)'
 position = "at"
 payload = '''
 function number_format(num, e_switch_point)
+    if type(num) ~= 'number' then return num end
+
     local sign = (num >= 0 and "") or "-"
     num = math.abs(num)'''
 match_indent = true

--- a/lovely/number_formatting.toml
+++ b/lovely/number_formatting.toml
@@ -145,6 +145,7 @@ if num ~= math.floor(num) and num < 100 then
   if formatted:sub(-1) == "0" then
     formatted = formatted:gsub("%.?0+$", "")
   end
+  if num < 0.01 then formatted = tostring(num) end
 else 
   formatted = string.format("%.0f", num)
 end

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -349,3 +349,21 @@ target = 'functions/UI_definitions.lua'
 pattern = '''(?<indent>[\t ]*)UIBox_button\(\{button = 'your_collection_blinds', label = \{localize\('b_blinds'\)\}, count = G\.DISCOVER_TALLIES\.blinds, minw = 5, minh = 2.0, id = 'your_collection_blinds', focus_args = \{snap_to = true\}\}\),'''
 position = 'after'
 payload = '''UIBox_button({button = 'your_collection_other_gameobjects', label = {localize('k_other')}, minw = 5, id = 'your_collection_other_gameobjects', focus_args = {snap_to = true}, func = 'is_other_gameobject_tabs'}),'''
+
+# Fix UIElement.config.chosen being overriden if choice=true is set
+# UIElement:click()
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+match_indent = true
+position = "after"
+pattern = "if self.config.choice then"
+payload = "    local chosen_temp = self.config.chosen"
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+match_indent = true
+position = "at"
+pattern = "self.config.chosen = true"
+payload = "self.config.chosen = chosen_temp or true"


### PR DESCRIPTION
**Edition improvements**

1. ARGS.send_to_shader[1] no longer infinitely increases (which makes it much easier to use in shaders). I have tested vanilla shaders running with this change for over an hour and they're doing fine.

2. edition.override_shape - edition parameter that allows shaders to change shape of the card without "default" card layer being rendered below it.

before change:
![image](https://github.com/user-attachments/assets/945ce9c9-bccc-4679-9ded-3bbb1939b00c)

after change:
![image](https://github.com/user-attachments/assets/c7b32385-e486-40c2-9a83-c8a09a67185c)

3. edition.no_shadow - small feature to disable shadows for shaders

**Number formatting fixes**

1. Display infinity properly (used to show `nan e 0`)

2. Remove trailing zeroes (e.g. `1.5` would get formatted to `1.50`, `1.001` to `1`)

3. Fix negative money formatting (-100 used to be -,100)

4. Scientific notation for negative money (by Wilsonthewolf, I just improved a few things)


**Performance fix**

While I was messing with event manager queues size, I noticed that the game would double the queue size for no apparent reason
After some testing, found that game queues Blind:set_blind for every card added (e.g. perkeo copying consumables, which doubles the wait time at end of shop).
I have made a fix that will only run that after blind started.


**UI fix**

Setting `UIElement.config.chosen` to 'vert' doesn't seem to work without `UIElement.config.choices = true`.
If `UIElement.config.choices == true` then whatever value is in chosen, it will get overriden to true.
Added 2 patches to fix this behaviour (I have spent over 2 hours trying to figure out why it works for challenges somehow and I did not succeed)