### PR TITLE
Fix space issue in path when restarting

### DIFF
--- a/core/utils.lua
+++ b/core/utils.lua
@@ -320,7 +320,7 @@ end
 
 function SMODS.restart_game()
     if love.system.getOS() ~= 'OS X' then
-        love.thread.newThread("os.execute(...)\n"):start(arg[-2] .. " " .. table.concat(arg, " "))
+        love.thread.newThread("os.execute(...)\n"):start('"' .. arg[-2] .. '" ' .. table.concat(arg, " "))
     else
         os.execute('sh "/Users/$USER/Library/Application Support/Steam/steamapps/common/Balatro/run_lovely.sh" &')
     end


### PR DESCRIPTION
`SMODS.restart_game` now respects spaces in file path when trying to restart the exe. 