### PR TITLE
Some more edition changes

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -958,10 +958,10 @@ function Card:set_edition(edition, immediate, silent)
 
 	local p_edition = G.P_CENTERS['e_' .. edition_type]
 
-	if p_edition.override_base_shader then
+	if p_edition.override_base_shader or p_edition.disable_base_shader then
 		self.ignore_base_shader[self.edition.key] = true
 	end
-	if p_edition.no_shadow then
+	if p_edition.no_shadow or p_edition.disable_shadow then
 		self.ignore_shadow[self.edition.key] = true
 	end
 

--- a/example_mods/Mods/EditionExamples/EditionExamples.lua
+++ b/example_mods/Mods/EditionExamples/EditionExamples.lua
@@ -142,8 +142,11 @@ SMODS.Edition({
             "nothin"
         }
     },
-    no_shadow = true, -- This will stop shadow from being rendered under the card
-    override_base_shader = true, -- This will stop extra layer being rendered below the shader. Necessary for edition that modify shape of a card.
+    -- Stop shadow from being rendered under the card
+    disable_shadow = true,
+    -- Stop extra layer from being rendered below the card. 
+    -- For edition that modify shape or transparency of the card.
+    disable_base_shader = true,
     shader = "flipped",
     discovered = true,
     unlocked = true,

--- a/example_mods/Mods/EditionExamples/README.md
+++ b/example_mods/Mods/EditionExamples/README.md
@@ -23,4 +23,13 @@ For a general guide, look at [LOVE2D introduction to shaders](https://blogs.love
 
 If you want to see vanilla Balatro shaders, unzip the Balatro.exe and go to `resources/shaders` folder.
 
-To see values for default externs check out `engine/sprite.lua` -> `Sprite:draw_shader`.
+To see values for default externs, check out `engine/sprite.lua` -> `Sprite:draw_shader`.
+
+
+## Useful shaders resources
+- [The book of shaders](https://thebookofshaders.com) - beginner friendly introduction to shaders.
+- [GLSL Editor](https://patriciogonzalezvivo.github.io/glslEditor/) - preview your fragment shaders live.
+- [Inigo Quilez articles](https://iquilezles.org/articles/) - in-depth articles on algorithms and techniques you could use in shaders. A lot of those are for 3D, but there's some 2D stuff as well.
+- [Shadertoy](https://www.shadertoy.com) - tons of shaders from other people to learn from. A lot of them are pretty complex and 3D, but you can find simple 2D ones.
+
+Note: in all resources the language is slightly different from LOVE2D shaders language, but the logic works the same way.

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -126,6 +126,21 @@ payload = '''
 if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and self:should_draw_base_shader() then'''
 match_indent = true
 
+# If shader modifies shape of card, this will stop "back" layer of the card being rendered.
+# invisible joker and vouchers.
+# Card:draw()
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.children.center:draw_shader('voucher', nil, self.ARGS.send_to_shader)'''
+position = "at"
+payload = '''
+if self:should_draw_base_shader() then
+    self.children.center:draw_shader('voucher', nil, self.ARGS.send_to_shader)
+end'''
+match_indent = true
+
 # Inject shaders applying to cards
 # Card:draw()
 [[patches]]

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -98,7 +98,9 @@ pattern = "bypass_lock = self.bypass_lock,"
 position = "after"
 payload = """
 unique_val = self.unique_val,
-unique_val__saved_ID = self.ID,"""
+unique_val__saved_ID = self.ID,
+ignore_base_shader = self.ignore_base_shader,
+ignore_shadow = self.ignore_shadow,"""
 match_indent = true
 
 # Card:load()
@@ -111,7 +113,10 @@ payload = """
 self.unique_val = cardTable.unique_val or self.unique_val
 if cardTable.unique_val__saved_ID and G.ID <= cardTable.unique_val__saved_ID then
     G.ID = cardTable.unique_val__saved_ID + 1
-end"""
+end
+
+self.ignore_base_shader = cardTable.ignore_base_shader or {}
+self.ignore_shadow = cardTable.ignore_shadow or {}"""
 match_indent = true
 
 ## Vars in card descriptions should use `card.ability` instead of `_c.config` where possible


### PR DESCRIPTION
Small tweaks with new edition options, and fix options not saving on save reload.
And updated readme for edition examples.


Can you also update wiki with `disable_base_shader` and `disable_shadow` parameters?

`disable_base_shader` - removes default shader applied to the card - `booster` (spectral cards, booster packs), `voucher` (invisible joker, vouchers) and `dissolve` (everything else). Easier to understand with example, you can use screenshots from [here](https://github.com/Steamopollys/Steamodded/pull/220).

Enable this if your shader modifies card transparency or shape in any way.

`disable_shadow` - disables shadow drawn under the card.

It would also make sense if the wiki pointed towards example mods folder as well as README in edition examples.

Or simply copy useful information from there to SMODS.Editions and yeet readme altogether.