### PR TITLE
feat: no config

### DIFF
--- a/core/ui.lua
+++ b/core/ui.lua
@@ -1044,6 +1044,7 @@ function G.FUNCS.mods_buttons_page(options)
 end
 
 function SMODS.load_mod_config(mod)
+	if mod.no_config then return end
 	local config = load(NFS.read(('config/%s.jkr'):format(mod.id)) or 'return {}', ('=[SMODS %s "config"]'):format(mod.id))()
 	local default_config = load(NFS.read(('%sconfig.lua'):format(mod.path)) or 'return {}', ('=[SMODS %s "default_config"]'):format(mod.id))()
 	mod.config = {} 
@@ -1053,6 +1054,7 @@ function SMODS.load_mod_config(mod)
 end
 SMODS:load_mod_config()
 function SMODS.save_mod_config(mod)
+	if mod.no_config then return end
 	NFS.createDirectory('config')
 	if not mod.config or not next(mod.config) then return false end
 	local serialized = 'return '..serialize(mod.config)

--- a/loader/loader.lua
+++ b/loader/loader.lua
@@ -55,7 +55,8 @@ function loadMods(modsDirectory)
         prefix        = { pattern = '%-%-%- PREFIX: (.-)\n' },
         version       = { pattern = '%-%-%- VERSION: (.-)\n', handle = function(x) return x and V(x):is_valid() and x or '0.0.0' end },
         outdated      = { pattern = { 'SMODS%.INIT', 'SMODS%.Deck' } },
-        dump_loc      = { pattern = { '%-%-%- DUMP_LOCALIZATION\n'}}
+        dump_loc      = { pattern = { '%-%-%- DUMP_LOCALIZATION\n'}},
+        no_config      = { pattern = { '%-%-%- NO_CONFIG\n'}}
     }
     
     local used_prefixes = {}


### PR DESCRIPTION
Adds the option to add `--- NO_CONFIG` to a mod's header to opt out of config handling via steamodded. This prevents SMODS from trying to read `config.lua` from the mod directory, or reading and writing to `config/<mod>.jkr`, which allows mods to use these for their own purposes