### PR TITLE
Loc text consistency

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -1405,8 +1405,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             self.rng_buffer[#self.rng_buffer + 1] = self.key
         end,
         process_loc_text = function(self)
-            SMODS.process_loc_text(G.localization.descriptions.Other, self.key:lower() .. '_seal', self.loc_txt,
-                'description')
+            SMODS.process_loc_text(G.localization.descriptions.Other, self.key:lower() .. '_seal', self.loc_txt)
             SMODS.process_loc_text(G.localization.misc.labels, self.key:lower() .. '_seal', self.loc_txt, 'label')
         end,
         get_obj = function(self, key) return G.P_SEALS[key] end
@@ -1591,7 +1590,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
         end,
         process_loc_text = function(self)
-            SMODS.process_loc_text(G.localization.misc.ranks, self.key, self.loc_txt)
+            SMODS.process_loc_text(G.localization.misc.ranks, self.key, self.loc_txt, 'name')
         end,
         inject = function(self)
             for _, suit in pairs(SMODS.Suits) do
@@ -2116,7 +2115,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         unlocked = function(self) return true end,
         class_prefix = 'c',
         process_loc_text = function(self)
-            SMODS.process_loc_text(G.localization.misc.challenge_names, self.key, self.loc_txt)
+            SMODS.process_loc_text(G.localization.misc.challenge_names, self.key, self.loc_txt, 'name')
         end,
         register = function(self)
             if self.registered then

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -1373,7 +1373,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             G.localization.descriptions.Blind['bl_wheel'].text[1] =
                 "#1#"..G.localization.descriptions.Blind['bl_wheel'].text[1]
             SMODS.Blind.process_loc_text(self)
-        end
+        end,
+        get_loc_debuff_text = function() return G.GAME.blind.loc_debuff_text end,
     })
 
     -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #198:
- Moves descriptions for seals out to match those of enhancements/editions (name/text/label all at top level)
- Move names for Ranks and Challenges into `loc_txt.name` so loc_txt is consistently a table
Fixes #210:
- Removes the extra prefix The Wheel's text sometimes has