### PR TITLE
Mipmap fixes and more shaders stuff

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -307,6 +307,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.Atlas = SMODS.GameObject:extend {
         obj_table = SMODS.Atlases,
         obj_buffer = {},
+        disable_mipmap = false,
         required_params = {
             'key',
             'path',
@@ -346,7 +347,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             G[self.atlas_table][self.key_noloc or self.key] = self
 
             local mipmap_level = SMODS.config.graphics_mipmap_level_options[SMODS.config.graphics_mipmap_level]
-            if mipmap_level and mipmap_level > 0 then
+            if not self.disable_mipmap and mipmap_level and mipmap_level > 0 then
                 self.image:setMipmapFilter('linear', mipmap_level)
             end
         end,

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -344,6 +344,11 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             self.image = love.graphics.newImage(self.image_data,
                 { mipmaps = true, dpiscale = G.SETTINGS.GRAPHICS.texture_scaling })
             G[self.atlas_table][self.key_noloc or self.key] = self
+
+            local mipmap_level = SMODS.config.graphics_mipmap_level_options[SMODS.config.graphics_mipmap_level]
+            if mipmap_level and mipmap_level > 0 then
+                self.image:setMipmapFilter('linear', mipmap_level)
+            end
         end,
         process_loc_text = function() end,
         pre_inject_class = function(self) 

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2495,14 +2495,16 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         sound = { sound = "foil1", per = 1.2, vol = 0.4 },
         required_params = {
             'key',
-            'shader'
+            'shader' -- can be set to `false` for shaderless edition
         },
-        -- other fields:
-        -- extra_cost
-
+        -- optional fields:
+        extra_cost = nil,
+        
         -- TODO badge colours. need to check how Steamodded already does badge colors
         -- other methods:
-        -- calculate(self)
+        calculate = nil, -- function (self)
+        on_apply = nil,  -- function (card) - modify card when edition is applied
+        on_remove = nil, -- function (card) - modify card when edition is removed
         register = function(self)
             self.config = self.config or {}
             SMODS.Edition.super.register(self)

--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -911,6 +911,11 @@ function Card:set_edition(edition, immediate, silent)
 	if old_edition then
 		self.ignore_base_shader[old_edition] = nil
 		self.ignore_shadow[old_edition] = nil
+
+		local on_old_edition_removed = G.P_CENTERS[old_edition] and G.P_CENTERS[old_edition].on_remove
+		if type(on_old_edition_removed) == "function" then
+			on_old_edition_removed(self)
+		end
 	end
 
 	local edition_type = nil
@@ -963,6 +968,11 @@ function Card:set_edition(edition, immediate, silent)
 	end
 	if p_edition.no_shadow or p_edition.disable_shadow then
 		self.ignore_shadow[self.edition.key] = true
+	end
+	
+	local on_edition_applied = p_edition.on_apply
+	if type(on_edition_applied) == "function" then
+		on_edition_applied(self)
 	end
 
 	for k, v in pairs(p_edition.config) do

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -154,7 +154,7 @@ position = "at"
 payload = '''
 if self.edition then
     for k, v in pairs(G.P_CENTER_POOLS.Edition) do
-        if self.edition[v.key:sub(3)] then
+        if self.edition[v.key:sub(3)] and v.shader then
             self.children.center:draw_shader(v.shader, nil, self.ARGS.send_to_shader)
             if self.children.front and self.ability.effect ~= 'Stone Card' and not self.config.center.replace_base_card then
                 self.children.front:draw_shader(v.shader, nil, self.ARGS.send_to_shader)


### PR DESCRIPTION
Should be added to wiki:

SMODS.Atlas
`disable_mipmap` - disable mipmap being applied to this texture

SMODS.Edition
`shader = false` support. Shaderless editions can use 2 new functions:
`on_apply = function (card)` - run when edition is applied to a card
`on_remove = function (card)` - run when edition is removed from the card 