### PR TITLE
fix: crash when unlocking/discovering blind

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -133,6 +133,8 @@ function create_UIBox_your_collection_blinds(exit)
 		card.children.center = temp_blind
 		temp_blind:set_role({major = card, role_type = 'Glued', draw_major = card})
 		card.set_sprites = function(...)
+			local args = {...}
+			if not args[1].animation then return end -- fix for debug unlock
 			local c = card.children.center
 			Card.set_sprites(...)
 			card.children.center = c


### PR DESCRIPTION
This fixes a crash when using 1 or 2 key with debug mode on a blind. Note if you want to test the fix, you can't use DebugPlus, as it crashes in another spot due to this change. 