### PR TITLE
fix: crash when unlocking/discovering blind... again

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -328,6 +328,8 @@ function G.FUNCS.your_collection_blinds_page(args)
 		card.children.center = temp_blind
 		temp_blind:set_role({major = card, role_type = 'Glued', draw_major = card})
 		card.set_sprites = function(...)
+			local args = {...}
+			if not args[1].animation then return end -- fix for debug unlock
 			local c = card.children.center
 			Card.set_sprites(...)
 			card.children.center = c


### PR DESCRIPTION
This is the same as #253, it just turns out that this code is done twice, and still crashes on the second page.