### PR TITLE
feat: show fail in crash handler

### DIFF
--- a/core/StackTracePlus.lua
+++ b/core/StackTracePlus.lua
@@ -501,6 +501,24 @@ function getDebugInfoForCrash()
                 if v.lovely_only or (v.lovely and not v.can_load) then
                     lovely_strings = lovely_strings .. "\n    " .. lovely_i .. ": " .. v.name
                     lovely_i = lovely_i + 1
+                    if not v.can_load then
+                        lovely_strings = lovely_strings .. "\n        Has Steamodded mod that failed to load."
+                        if #v.load_issues.dependencies > 0 then
+                            lovely_strings = lovely_strings .. "\n        Missing Dependencies:"
+                            for k, v in ipairs(v.load_issues.dependencies) do
+                                lovely_strings = lovely_strings .. "\n            " .. k .. ". " .. v
+                            end
+                        end
+                        if #v.load_issues.conflicts > 0 then
+                            lovely_strings = lovely_strings .. "\n        Conflicts:"
+                            for k, v in ipairs(v.load_issues.conflicts) do
+                                lovely_strings = lovely_strings .. "\n            " .. k .. ". " .. v
+                            end
+                        end
+                        if v.load_issues.outdated then
+                            lovely_strings = lovely_strings .. "\n        Outdated Mod"
+                        end
+                    end
                 else
                     mod_strings = mod_strings .. "\n    " .. i .. ": " .. v.name .. " by " ..
                                       table.concat(v.author, ", ") .. " [ID: " .. v.id ..


### PR DESCRIPTION
This shows in the crash handler when a lovely mod has a steamodded part that failed to load. This does not show purely steamodded mods that failed to load, as they are not going to cause crashes.

![image](https://github.com/user-attachments/assets/5ad41d97-d5aa-444e-b0f9-5d044a3775c9)
