### PR TITLE
Fix restart when no mods are found

### DIFF
--- a/core/ui.lua
+++ b/core/ui.lua
@@ -1109,7 +1109,7 @@ end
 function G.FUNCS.exit_mods(e)
 	G.ACTIVE_MOD_UI = nil
 	SMODS.save_all_config()
-    if SMODS.full_restart ~= 0 then
+    if SMODS.full_restart and SMODS.full_restart ~= 0 then
 		-- launch a new instance of the game and quit the current one
 		SMODS.restart_game()
     end


### PR DESCRIPTION
Steamodded would restart the entire game when closing the mods menu, because/if no mods were found.
Now checks if the delta mods counter actually exists before restarting.