### PR TITLE
Enhancement clean ups

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2554,9 +2554,9 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
             SMODS.Enhancement.super.generate_ui(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
             if specific_vars and specific_vars.bonus_chips then
-                local remaining_bonus_chips = specific_vars.bonus_chips - (self.loc_subtract_extra_chips or 0)
+                local remaining_bonus_chips = specific_vars.bonus_chips - (self.config.bonus or 0)
                 if remaining_bonus_chips > 0 then
-                    localize { type = 'other', key = 'card_extra_chips', nodes = desc_nodes, vars = { specific_vars.bonus_chips - (self.loc_subtract_extra_chips or 0) } }
+                    localize { type = 'other', key = 'card_extra_chips', nodes = desc_nodes, vars = { specific_vars.bonus_chips - (self.config.bonus or 0) } }
                 end
             end
         end,
@@ -2594,7 +2594,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     --         }
     --     end
     -- })
-    -- stone_card.loc_subtract_extra_chips = stone_card.config.bonus
 
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.Shader

--- a/core/utils.lua
+++ b/core/utils.lua
@@ -589,10 +589,10 @@ function SMODS.poll_seal(args)
             local seal_option = {}
             if type(v) == 'string' then
                 assert(G.P_SEALS[v])
-                seal_option = { name = v, weight = G.P_SEALS[v].weight or 5 } -- default weight set to 5 to replicate base game weighting
+                seal_option = { key = v, weight = G.P_SEALS[v].weight or 5 } -- default weight set to 5 to replicate base game weighting
             elseif type(v) == 'table' then
-                assert(G.P_SEALS[v.name])
-                seal_option = { name = v.name, weight = v.weight }
+                assert(G.P_SEALS[v.key])
+                seal_option = { key = v.key, weight = v.weight }
             end
             if seal_option.weight > 0 then
                 table.insert(available_seals, seal_option)
@@ -604,7 +604,7 @@ function SMODS.poll_seal(args)
 
     local type_weight = 0 -- modified weight total
     for _,v in ipairs(available_seals) do
-        v.weight = G.P_SEALS[v.name].get_weight and G.P_SEALS[v.name]:get_weight() or v.weight
+        v.weight = G.P_SEALS[v.key].get_weight and G.P_SEALS[v.key]:get_weight() or v.weight
         type_weight = type_weight + v.weight
     end
     
@@ -615,7 +615,7 @@ function SMODS.poll_seal(args)
         for k, v in ipairs(available_seals) do
             weight_i = weight_i + v.weight
             if seal_type_poll > 1 - (weight_i / type_weight) then
-                return v.name
+                return v.key
             end
         end
     end
@@ -676,4 +676,52 @@ function convert_save_data()
         end
     end
     G:save_settings()
+end
+
+function SMODS.poll_enhancement(args)
+    args = args or {}
+    local key = args.key or 'std_enhance'
+    local mod = args.mod or 1
+    local guaranteed = args.guaranteed or false
+    local options = args.options or get_current_pool("Enhanced")
+    local type_key = args.type_key or key.."type"..G.GAME.round_resets.ante
+    key = key..G.GAME.round_resets.ante
+
+    local available_enhancements = {}
+    local total_weight = 0
+    for _, v in ipairs(options) do
+        if v ~= "UNAVAILABLE" then
+            local enhance_option = {}
+            if type(v) == 'string' then
+                assert(G.P_CENTERS[v])
+                enhance_option = { key = v, weight = G.P_CENTERS[v].weight or 5 } -- default weight set to 5 to replicate base game weighting
+            elseif type(v) == 'table' then
+                assert(G.P_CENTERS[v.key])
+                enhance_option = { key = v.key, weight = v.weight }
+            end
+            if enhance_option.weight > 0 then
+                table.insert(available_enhancements, enhance_option)
+                total_weight = total_weight + enhance_option.weight
+            end
+        end
+	end
+    total_weight = total_weight + (total_weight / 40 * 60) -- set base rate to 40%
+
+    local type_weight = 0 -- modified weight total
+    for _,v in ipairs(available_enhancements) do
+        v.weight = G.P_CENTERS[v.key].get_weight and G.P_CENTERS[v.key]:get_weight() or v.weight
+        type_weight = type_weight + v.weight
+    end
+    
+    local enhance_poll = pseudorandom(pseudoseed(key))
+    if enhance_poll > 1 - (type_weight*mod / total_weight) or guaranteed then -- is an enhancement selected
+        local seal_type_poll = pseudorandom(pseudoseed(type_key)) -- which enhancement is selected
+        local weight_i = 0
+        for k, v in ipairs(available_enhancements) do
+            weight_i = weight_i + v.weight
+            if seal_type_poll > 1 - (weight_i / type_weight) then
+                return v.key
+            end
+        end
+    end
 end

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -205,8 +205,6 @@ for k, v in pairs(G.P_CENTER_POOLS.Edition) do
     if self.edition[v.key:sub(3)] then
         if v.extra_cost then
             self.extra_cost = self.extra_cost + v.extra_cost
-        else
-            self.extra_cost = 0
         end
     end
 end'''


### PR DESCRIPTION
- Editions `extra_cost` value ignored `G.GAME.inflation`
- Enhancements that provide bonus chips have their values seperated from permanent bonus effects, such as Hiker
- Added `SMODS.poll_enhancement` *(follows same structure as other poll functions)*
- Renamed `name` in `SMODS.poll_seal` to `key` *(will break current uses of function with defined options as `{name:weight}` paired tables)*