### PR TITLE
Deck Skins

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2106,6 +2106,80 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
         end,
     })
+    -------------------------------------------------------------------------------------------------
+    ----- API CODE GameObject.DeckSkin
+    -------------------------------------------------------------------------------------------------
+
+    SMODS.DeckSkins = {}
+    SMODS.DeckSkin =SMODS.GameObject:extend {
+        obj_table = SMODS.DeckSkins,
+        obj_buffer = {},
+        required_params = {
+            'key',
+            'suit',
+            'ranks',
+            'lc_atlas',
+        },
+        register = function (self)
+            if self:check_dependencies() then
+                if self.hc_atals == nil then self.hc_atals = self.lc_atlas end
+                if self.posStyle == nil then self.posStyle = 'deck' end
+
+                self.obj_table[self.key] = self
+                self.obj_buffer[#self.obj_buffer + 1] = self.key
+                self.registered = true
+            end 
+        end,
+        inject = function (self)
+            local options = G.COLLABS.options[self.suit]
+            options[#options + 1] = self.key
+        end
+    }
+--[[
+        collabs={
+            Clubs={
+                default="Default",
+                collab_VS="Vampire Survivors",
+                collab_STS="Slay the Spire",
+            },
+            Diamonds={
+                default="Default",
+                collab_DTD="Dave the Diver",
+                collab_SV="Stardew Valley",
+            },
+            Hearts={
+                default="Default",
+                collab_AU="Among Us",
+                collab_TBoI="The Binding of Isaac",
+            },
+            Spades={
+                default="Default",
+                collab_TW="The Witcher",
+                collab_CYP="Cyberpunk 2077",
+            },
+        },
+
+
+]]--
+    for suitName, options in pairs(G.COLLABS.options) do
+        --start at 2 to skip default
+        for i = 2, #options do
+            SMODS.DeckSkin{
+                key = options[i],
+                suit = suitName,
+                ranks = {'Jack', 'Queen', 'King'},
+                lc_atlas = options[i] .. '_1',
+                hc_atlas = options[i] .. '_2',
+                posStyle = 'collab'
+            }
+        end
+    end
+
+    --Clear 'Friends of Jimbo' skins so they can be handled via the same pipeline
+    G.COLLABS.options['Spades'] = {'default'}
+    G.COLLABS.options['Hearts'] = {'default'}
+    G.COLLABS.options['Clubs'] = {'default'}
+    G.COLLABS.options['Diamonds'] = {'default'}
 
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.PokerHand

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2124,7 +2124,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         set = 'DeckSkin',
         process_loc_text = function(self)
             if G.localization.misc.collabs[self.suit] == nil then
-                G.localization.misc.collabs[self.suit] = {["1"] = 'default'}
+                G.localization.misc.collabs[self.suit] = {["1"] = 'Default'}
             end
 
             if self.loc_txt and self.loc_txt[G.SETTINGS.language] then
@@ -2161,6 +2161,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
         end,
         inject = function (self)
+            if G.COLLABS.options[self.suit] == nil then
+                G.COLLABS.options[self.suit] = {'default'}
+            end
+
             local options = G.COLLABS.options[self.suit]
             options[#options + 1] = self.key
         end
@@ -2181,10 +2185,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     end
 
     --Clear 'Friends of Jimbo' skins so they can be handled via the same pipeline
-    G.COLLABS.options['Spades'] = {'default'}
-    G.COLLABS.options['Hearts'] = {'default'}
-    G.COLLABS.options['Clubs'] = {'default'}
-    G.COLLABS.options['Diamonds'] = {'default'}
+    G.COLLABS.options = {}
 
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.PokerHand

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2110,6 +2110,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     ----- API CODE GameObject.DeckSkin
     -------------------------------------------------------------------------------------------------
 
+    local deck_skin_count_by_suit = {}
     SMODS.DeckSkins = {}
     SMODS.DeckSkin =SMODS.GameObject:extend {
         obj_table = SMODS.DeckSkins,
@@ -2120,12 +2121,36 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             'ranks',
             'lc_atlas',
         },
+        process_loc_text = function(self)
+            if G.localization.misc.collabs[self.suit] == nil then
+                G.localization.misc.collabs[self.suit] = {["1"] = 'default'}
+            end
+
+            if G.localization.misc.collabs[self.suit][self.suit_index .. ''] == nil then
+                local localized = self.key
+                if self.loc_txt and self.loc_txt[G.SETTINGS.language] then
+                    localized = self.loc_txt[G.SETTINGS.language]
+                end
+
+                G.localization.misc.collabs[self.suit][self.suit_index .. ''] = localized
+            end
+        end,
         register = function (self)
             if self:check_dependencies() then
                 if self.hc_atals == nil then self.hc_atals = self.lc_atlas end
                 if self.posStyle == nil then self.posStyle = 'deck' end
 
                 self.obj_table[self.key] = self
+
+                if deck_skin_count_by_suit[self.suit] then
+                    self.suit_index  = deck_skin_count_by_suit[self.suit] + 1
+                else
+                    --start at 2 for default
+                    self.suit_index = 2
+                end
+                deck_skin_count_by_suit[self.suit] = self.suit_index
+                sendDebugMessage('registered DeckSkin ' .. self.suit .. ' ' .. self.suit_index .. ' ' .. self.key)
+
                 self.obj_buffer[#self.obj_buffer + 1] = self.key
                 self.registered = true
             end 

--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -2121,24 +2121,30 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             'ranks',
             'lc_atlas',
         },
+        set = 'DeckSkin',
         process_loc_text = function(self)
             if G.localization.misc.collabs[self.suit] == nil then
                 G.localization.misc.collabs[self.suit] = {["1"] = 'default'}
             end
 
-            if G.localization.misc.collabs[self.suit][self.suit_index .. ''] == nil then
-                local localized = self.key
-                if self.loc_txt and self.loc_txt[G.SETTINGS.language] then
-                    localized = self.loc_txt[G.SETTINGS.language]
-                end
-
-                G.localization.misc.collabs[self.suit][self.suit_index .. ''] = localized
+            if self.loc_txt and self.loc_txt[G.SETTINGS.language] then
+                G.localization.misc.collabs[self.suit][self.suit_index .. ''] = self.loc_txt[G.SETTINGS.language]
+            elseif G.localization.misc.collabs[self.suit][self.suit_index .. ''] == nil then
+                G.localization.misc.collabs[self.suit][self.suit_index .. ''] = self.key
             end
         end,
         register = function (self)
+            if self.registered then
+                sendWarnMessage(('Detected duplicate register call on DeckSkin %s'):format(self.key), self.set)
+                return
+            end
             if self:check_dependencies() then
                 if self.hc_atals == nil then self.hc_atals = self.lc_atlas end
                 if self.posStyle == nil then self.posStyle = 'deck' end
+
+                if not (self.posStyle == 'collab' or self.posStyle == 'suit' or self.posStyle == 'deck') then
+                    sendWarnMessage(('%s is not a valid posStyle on DeckSkin %s. Supported posStyle values are \'collab\', \'suit\' and \'deck\''):format(self.posStyle, self.key), self.set)
+                end
 
                 self.obj_table[self.key] = self
 
@@ -2149,43 +2155,17 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     self.suit_index = 2
                 end
                 deck_skin_count_by_suit[self.suit] = self.suit_index
-                sendDebugMessage('registered DeckSkin ' .. self.suit .. ' ' .. self.suit_index .. ' ' .. self.key)
 
                 self.obj_buffer[#self.obj_buffer + 1] = self.key
                 self.registered = true
-            end 
+            end
         end,
         inject = function (self)
             local options = G.COLLABS.options[self.suit]
             options[#options + 1] = self.key
         end
     }
---[[
-        collabs={
-            Clubs={
-                default="Default",
-                collab_VS="Vampire Survivors",
-                collab_STS="Slay the Spire",
-            },
-            Diamonds={
-                default="Default",
-                collab_DTD="Dave the Diver",
-                collab_SV="Stardew Valley",
-            },
-            Hearts={
-                default="Default",
-                collab_AU="Among Us",
-                collab_TBoI="The Binding of Isaac",
-            },
-            Spades={
-                default="Default",
-                collab_TW="The Witcher",
-                collab_CYP="Cyberpunk 2077",
-            },
-        },
 
-
-]]--
     for suitName, options in pairs(G.COLLABS.options) do
         --start at 2 to skip default
         for i = 2, #options do

--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -5,7 +5,6 @@ priority = 0
 
 #========================================================#
 # Choose any rank for custom deck and use provided atlas #
-# and rework translation too I guess#
 #========================================================#
 [[patches]]
 [patches.regex]
@@ -83,6 +82,39 @@ until rank.next[1] == '2'
 
 for i = #cards, 1, -1 do
     face_cards:emplace(cards[i])
+end
+'''
+match_indent = true
+
+[[patches]]
+[patches.regex]
+target = "functions/UI_definitions.lua"
+pattern = '''function create_UIBox_customize_deck()([\s\S]*?)end'''
+position = "at"
+payload = '''
+function create_UIBox_customize_deck()
+  local suitTabs = {}
+
+  local index = 1
+  for suitKey, _ in pairs(SMODS.Suits) do
+    suitTabs[index] = {
+                label = localize(suitKey, 'suits_plural'),
+                tab_definition_function = G.UIDEF.custom_deck_tab,
+                tab_definition_function_args = suitKey
+            }
+    index = index + 1
+  end
+
+  suitTabs[1].chosen = true
+
+  local t = create_UIBox_generic_options({ back_func = 'options', snap_back = nil, contents = {
+    {n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
+      create_tabs(
+        {tabs = suitTabs, snap_to_nav = true, no_shoulders = true}
+    )}}}
+  })
+
+  return t
 end
 '''
 match_indent = true

--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -48,10 +48,17 @@ target = "functions/UI_definitions.lua"
 pattern = '''local face_cards = CardArea\(([\s\S]*?)\)'''
 position = "at"
 payload = '''
-
 local rankCount = 0
-for _,_ in pairs(SMODS.Ranks) do
-    rankCount = rankCount + 1
+local lookup = {}
+local options = G.COLLABS.options[_suit]
+for i = 2, #options do
+    local skin = SMODS.DeckSkins[options[i]]
+    for j = 1, #skin.ranks do
+        if not lookup[skin.ranks[j]] then
+            lookup[skin.ranks[j]] = true
+            rankCount = rankCount + 1
+        end
+    end
 end
 
 local face_cards = CardArea(
@@ -70,14 +77,17 @@ position = "at"
 payload = '''
 local rank = SMODS.Ranks['2']
 local cards = {}
+local smodSuit = SMODS.Suits[_suit]
 repeat
-    local card_code = (string.sub(_suit, 1, 1))..'_'..rank.card_key
-    local card = Card(0,0, G.CARD_W*1.2, G.CARD_H*1.2, G.P_CARDS[card_code], G.P_CENTERS.c_base)
-    card.no_ui = true
-    
-    cards[#cards + 1] = card
+    if lookup[rank.key] then
+        local card_code = smodSuit.card_key .. '_' .. rank.card_key
+        local card = Card(0,0, G.CARD_W*1.2, G.CARD_H*1.2, G.P_CARDS[card_code], G.P_CENTERS.c_base)
+        card.no_ui = true
+        
+        cards[#cards + 1] = card
+    end
     rank = SMODS.Ranks[rank.next[1]]
-until rank.next[1] == '2'
+until rank == SMODS.Ranks['2']
 
 for i = #cards, 1, -1 do
     face_cards:emplace(cards[i])
@@ -95,16 +105,20 @@ function create_UIBox_customize_deck()
   local suitTabs = {}
 
   local index = 1
-  for suitKey, _ in pairs(SMODS.Suits) do
-    suitTabs[index] = {
-                label = localize(suitKey, 'suits_plural'),
-                tab_definition_function = G.UIDEF.custom_deck_tab,
-                tab_definition_function_args = suitKey
-            }
-    index = index + 1
+  for i, suit in ipairs(SMODS.Suit:obj_list(true)) do
+    if G.COLLABS.options[suit.key] then
+        suitTabs[index] = {
+                    label = localize(suit.key, 'suits_plural'),
+                    tab_definition_function = G.UIDEF.custom_deck_tab,
+                    tab_definition_function_args = suit.key
+                }
+        index = index + 1
+    end
   end
 
-  suitTabs[1].chosen = true
+  if suitTabs[1] then
+    suitTabs[1].chosen = true
+  end
 
   local t = create_UIBox_generic_options({ back_func = 'options', snap_back = nil, contents = {
     {n=G.UIT.R, config={align = "cm", padding = 0}, nodes={

--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -1,0 +1,96 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+#========================================================#
+# Choose any rank for custom deck and use provided atlas #
+# and rework translation too I guess#
+#========================================================#
+[[patches]]
+[patches.regex]
+target = "functions/misc_functions.lua"
+pattern = '''if _front and _front.suit and \(_front.value == 'Jack' or _front.value == 'Queen' or _front.value == 'King'\) then([\s\S]*?)end([\s\S]*?)end([\s\S]*?)end'''
+position = "at"
+payload = '''
+if _front and _front.suit and G.SETTINGS.CUSTOM_DECK and G.SETTINGS.CUSTOM_DECK.Collabs then
+    local collab = G.SETTINGS.CUSTOM_DECK.Collabs[_front.suit]
+    if collab and collab ~= 'default' then
+        local deckSkin = SMODS.DeckSkins[collab]
+        if deckSkin then
+            local hasRank = false
+            for i = 1, #deckSkin.ranks do
+                if deckSkin.ranks[i] == _front.value then hasRank = true break end
+            end
+            if hasRank then
+                local atlas = G.ASSET_ATLAS[G.SETTINGS.colourblind_option and deckSkin.hc_atlas or deckSkin.lc_atlas]
+                if atlas then
+                    if  deckSkin.posStyle == 'collab' then
+                        return atlas, G.COLLABS.pos[_front.value]
+                    elseif deckSkin.posStyle == 'deck' then
+                        return atlas, _front.pos
+                    end
+                end
+            end
+        end
+    end
+end
+'''
+match_indent = true
+
+[[patches]]
+[patches.regex]
+target = "functions/misc_functions.lua"
+pattern = '''local loc_options = localize\(_suit, 'collabs'\)([\s\S]*?)end([\s\S]*?)end'''
+position = "at"
+payload = '''
+
+local loc_options = {}
+
+for _, deckSkin in ipair(SMODS.DeckSkins) do
+    deckSkin.key
+end
+
+'''
+
+#=======================#
+# Extend custom deck ui #
+#=======================#
+[[patches]]
+[patches.regex]
+target = "functions/UI_definitions.lua"
+pattern = '''local face_cards = CardArea\(([\s\S]*?)\)'''
+position = "at"
+payload = '''
+
+local rankCount = 0
+	
+for _, rank in pairs(SMODS.Ranks) do
+    rankCount = rankCount + 1
+end
+
+local face_cards = CardArea(
+    0,0,
+    math.min(math.max(rankCount*G.CARD_W*0.6, 4*G.CARD_W), 10*G.CARD_W),
+    1.4*G.CARD_H, 
+    {card_limit = rankCount, type = 'title', highlight_limit = 0})
+'''
+match_indent = true
+
+[[patches]]
+[patches.regex]
+target = "functions/UI_definitions.lua"
+pattern = '''for i = 1, 3 do([\s\S]*?)end'''
+position = "at"
+payload = '''
+local rank = SMODS.Ranks['2']
+repeat
+    local card_code = (string.sub(_suit, 1, 1))..'_'..rank.card_key
+    local card = Card(0,0, G.CARD_W*1.2, G.CARD_H*1.2, G.P_CARDS[card_code], G.P_CENTERS.c_base)
+    card.no_ui = true
+    face_cards:emplace(card)
+
+    rank = SMODS.Ranks[rank.next[1]]
+until rank.next[1] == '2'
+'''
+match_indent = true

--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -27,6 +27,8 @@ if _front and _front.suit and G.SETTINGS.CUSTOM_DECK and G.SETTINGS.CUSTOM_DECK.
                 if atlas then
                     if  deckSkin.posStyle == 'collab' then
                         return atlas, G.COLLABS.pos[_front.value]
+                    elseif deckSkin.posStyle == 'suit' then
+                        return atlas, { x = _front.pos.x, y = 0}
                     elseif deckSkin.posStyle == 'deck' then
                         return atlas, _front.pos
                     end
@@ -37,21 +39,6 @@ if _front and _front.suit and G.SETTINGS.CUSTOM_DECK and G.SETTINGS.CUSTOM_DECK.
 end
 '''
 match_indent = true
-
-[[patches]]
-[patches.regex]
-target = "functions/misc_functions.lua"
-pattern = '''local loc_options = localize\(_suit, 'collabs'\)([\s\S]*?)end([\s\S]*?)end'''
-position = "at"
-payload = '''
-
-local loc_options = {}
-
-for _, deckSkin in ipair(SMODS.DeckSkins) do
-    deckSkin.key
-end
-
-'''
 
 #=======================#
 # Extend custom deck ui #
@@ -84,13 +71,18 @@ pattern = '''for i = 1, 3 do([\s\S]*?)end'''
 position = "at"
 payload = '''
 local rank = SMODS.Ranks['2']
+local cards = {}
 repeat
     local card_code = (string.sub(_suit, 1, 1))..'_'..rank.card_key
     local card = Card(0,0, G.CARD_W*1.2, G.CARD_H*1.2, G.P_CARDS[card_code], G.P_CENTERS.c_base)
     card.no_ui = true
-    face_cards:emplace(card)
-
+    
+    cards[#cards + 1] = card
     rank = SMODS.Ranks[rank.next[1]]
 until rank.next[1] == '2'
+
+for i = #cards, 1, -1 do
+    face_cards:emplace(cards[i])
+end
 '''
 match_indent = true

--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -50,8 +50,7 @@ position = "at"
 payload = '''
 
 local rankCount = 0
-	
-for _, rank in pairs(SMODS.Ranks) do
+for _,_ in pairs(SMODS.Ranks) do
     rankCount = rankCount + 1
 end
 


### PR DESCRIPTION
Adds DeckSkin as a GameObject and provides an API for mods to add deck skins.

The API accepts:
- key - The identifying key.
- suit - The suit this DeckSkin applies to.
- ranks - The ranks this DeckSkin supports.
- lc_atlas - The name of the atlas used for the DeckSkin's low contrast texture.
- hc_atlas - Optional - The name of the atlas used for the DeckSkin's low contrast texture. If missing the lc_atlas will be used instead.
- posStyle - Optional - Determines the way cards in the textures are accessed. If 'collab' positions will be taken from G.COLLABS.pos, which matches the current layout of Balatro's collabs. If 'deck' positions will be taken from the card's pos, which matches the current layout of the deck texutre. if 'suit' the y position will be 0 and the x position will be taken from the card's pos. If missing will default to 'deck'.
- loc_txt - Optional - The translated name of the DeckSkin. If missing and a translation doesn't already exist, the key will be used.

--**Usage Example**--
SMODS.Atlas{
    key = "myLowContrast",
    path = "myLowContrast.png",
    px = 71,
    py = 95,
    atlas_table = 'ASSET_ATLAS'
}

SMODS.Atlas{
    key = "myHighContrast",
    path = "myHighContrast.png",
    px = 71,
    py = 95,
    atlas_table = 'ASSET_ATLAS'
}

SMODS.DeckSkin{
	key = "myDeckSkin",
	suit = 'Spades',
	ranks = {
		'2', '3', '4', '5', '6', '7', '8', '9', '10', 'Jack', 'Queen', "King", "Ace"
	},
	hc_atlas = "myHighContrast",
	lc_atlas = "myLowContrast",
	loc_txt = {
		['en-us'] = 'My Cool Deck Skin!'
	},
	posStyle = 'suit'
}

Also expands the 'Customize Deck' ui to show all suits, ranks and DeckSkins, including modded ones.