### PR TITLE
Add coroutine to intertwine updates/gc cycles with scoring

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -2106,8 +2106,9 @@ function love.update(...)
 			--this coroutine allows us to stagger GC cycles through
 			--the main source of waste in terms of memory (especially w joker retriggers) is through local variables that become garbage
 			--this practically eliminates the memory overhead of scoring
-			--event queue overhead seems to not exist until scoring finalizes
-			--event manager has to wait for scoring to finish until it can keep processing events anyways
+			--event queue overhead seems to not exist if Talismans Disable Scoring Animations is off.
+			--event manager has to wait for scoring to finish until it can keep processing events anyways.
+			
             collectgarbage("collect")
 	    G.LAST_SCORING_YIELD = love.timer.getTime()
             coroutine.resume(G.SCORING_COROUTINE)

--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -2109,6 +2109,7 @@ function love.update(...)
 			--event queue overhead seems to not exist until scoring finalizes
 			--event manager has to wait for scoring to finish until it can keep processing events anyways
             collectgarbage("collect")
+	    G.LAST_SCORING_YIELD = love.timer.getTime()
             coroutine.resume(G.SCORING_COROUTINE)
         end
     end
@@ -2121,7 +2122,6 @@ local cj = Card.calculate_joker
 function Card:calculate_joker(context)
 	--scoring coroutine
 	if ((love.timer.getTime() - G.LAST_SCORING_YIELD) > TIME_BETWEEN_SCORING_FRAMES) and coroutine.running() then
-	        G.LAST_SCORING_YIELD = love.timer.getTime()
 	        coroutine.yield()
     	end
 	local ret, triggered = cj(self, context)

--- a/lovely/joker_retrigger.toml
+++ b/lovely/joker_retrigger.toml
@@ -612,3 +612,20 @@ pattern = "for h = 1, eval.jokers.repetitions do"
 position = "before"
 match_indent = true
 payload = "if not eval.jokers.repetitions then eval.jokers.repetitions = 0 end"
+
+# Scoring coroutine
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = "check_for_unlock({type = 'play_all_hearts'})"
+position = 'before'
+payload = 'if G.SCORING_COROUTINE then return false end '
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = "G.STATE_COMPLETE = false"
+position = 'before'
+payload = 'if G.SCORING_COROUTINE then return false end '
+match_indent = true


### PR DESCRIPTION
This eliminates the memory overhead of scoring, and eliminates the issue of the game freezing while scoring is in progress.

An overlay with a simple "Calculating..." text appears while scoring, and the user has no control while this is happening.

The overlay only appears during the actual calculations involved in scoring.

The scoring animations the user sees are outside of the calculations, and as such the obstruction of the overlay disappears afterwards.

Updates run 10 times a second (along with GC cycles). If scoring takes less than a tenth of a second, the effects of the coroutine are nonexistent.

It's to be noted that scoring will always take up at least 0.1 seconds. The GC cycle time isn't included.

It seems that updates take a shit ton of time if scoring animations are enabled, likely due to the event manager iterating through all of the events in queue. This is negligible, since if you're performing that many retriggers with scoring animations on, the time it'll take to fully run through all the animations would be months anyways.