### PR TITLE
Fix omit field not registering

### DIFF
--- a/core/game_object.lua
+++ b/core/game_object.lua
@@ -1109,7 +1109,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end,
         inject = function(self)
             G.P_CENTERS[self.key] = self
-            SMODS.insert_pool(G.P_CENTER_POOLS[self.set], self)
+            if not self.omit then SMODS.insert_pool(G.P_CENTER_POOLS[self.set], self) end
             for k, v in pairs(SMODS.ObjectTypes) do
                 -- Should "cards" be formatted as `{[<center key>] = true}` or {<center key>}?
                 -- Changing "cards" and "pools" wouldn't be hard to do, just depends on preferred format
@@ -1295,6 +1295,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         atlas = 'centers',
         pos = { x = 0, y = 0 },
         config = {},
+        omit = false,
         unlock_condition = {},
         stake = 1,
         class_prefix = 'b',


### PR DESCRIPTION
The omit field in the default game is normally used for omitting the challenge deck from the center_pools table, however steamodded did not take this into account. I fixed this issue by just checking whether the field is true or not and also adding a new explicit field to the Back constructor.