### PR TITLE
Update real_card_limit when creating negative (playing) card

### DIFF
--- a/core/overrides.lua
+++ b/core/overrides.lua
@@ -1495,6 +1495,9 @@ function Card:set_edition(edition, immediate, silent)
 				G.E_MANAGER:add_event(Event({
 					trigger = 'immediate',
 					func = function()
+						if G.hand.config.real_card_limit then
+							G.hand.config.real_card_limit = G.hand.config.real_card_limit + v
+						end
 						G.hand.config.card_limit = G.hand.config.card_limit + v
 						G.FUNCS.draw_from_deck_to_hand(v)
 						return true


### PR DESCRIPTION
Fixes situations where creating negative cards results in a negative handsize after playing or discarding them

Repro case:

- Start a new game
- Use debug tools to mark a card as negative. Hand size is now 9/9 as a new card is drawn.
- Discard the negative card. Hand size is now 8/8 as expected.
- Make another negative card and discard it. Hand size is now 8/7. Hand size is permanently reduced.

This appears to be happening because discarding a negative card updates real_hand_size, where creating a new negative card doesn't.