### PR TITLE
Create DeckSkinTemplate as an example mod

### DIFF
--- a/example_mods/Mods/DeckSkinTemplate/DeckSkinTemplate.lua
+++ b/example_mods/Mods/DeckSkinTemplate/DeckSkinTemplate.lua
@@ -1,0 +1,61 @@
+--- STEAMODDED HEADER
+--- MOD_NAME: NAME OF MOD (required)
+--- MOD_ID: UNIQUE MOD ID (required)
+--- PREFIX: UNIQUE MOD PREFIX (required)
+--- MOD_AUTHOR: [ARTIST, CODER, Victin] (required)
+--- MOD_DESCRIPTION: WHAT IS THIS (required)
+--- LOADER_VERSION_GEQ: 1.0.0
+--- VERSION: 1.0.0
+--- BADGE_COLOR: FFFFFF
+
+local atlas_key = 'PREFIX_NAMEOFCHOICE' -- Format: PREFIX_KEY
+-- See end of file for notes
+local atlas_path = 'imagename.png' -- Filename for the image in the asset folder
+local atlas_path_hc = nil -- Filename for the high-contrast version of the texture, if existing
+
+local suits = {'hearts', 'clubs', 'diamonds', 'spades'} -- Which suits to replace
+local ranks = {'2', '3', '4', '5', '6', '7', '8', '9', '10', 'Jack', 'Queen', "King", "Ace",} -- Which ranks to replace
+
+local description = 'In-game name of texture in selection menu' -- English-language description, also used as default
+
+-----------------------------------------------------------
+-- You should only need to change things above this line --
+-----------------------------------------------------------
+
+SMODS.Atlas{  
+    key = atlas_key,
+    px = 71,
+    py = 95,
+    path = atlas_path,
+    prefix_config = {key = false}, -- See end of file for notes
+}
+
+if atlas_path_hc then
+    SMODS.Atlas{  
+        key = atlas_key..'_hc',
+        px = 71,
+        py = 95,
+        path = atlas_path_hc,
+        prefix_config = {key = false}, -- See end of file for notes
+    }
+end
+
+for _, suit in ipairs(suits) do
+    SMODS.DeckSkin{
+        key = suit.."_skin",
+        suit = suit:gsub("^%l", string.upper),
+        ranks = ranks,
+        lc_atlas = atlas_key,
+        hc_atlas = (atlas_path_hc and atlas_key..'_hc') or atlas_key,
+        loc_txt = {
+            ['en-us'] = description
+        },
+        posStyle = 'deck'
+    }
+end
+
+-- Notes:
+
+-- The current version of Steamodded has a bug with prefixes in mods including `DeckSkin`s.
+-- By manually including the prefix in the atlas' key, this should keep the mod functional
+-- even after this bug is fixed.


### PR DESCRIPTION
This template should simplify the DeckSkin creation process for less code-savvy users.

Instructions:
1. **Create playing card textures** for each suit in a single file, organized as in the base game. **From top to bottom:** Hearts, Clubs, Diamonds, and Spades. **From left to right:** in rank order, starting from 2 and ending at Ace. **Optional:** make a high-contrast version of the texture;
2. **Put** the normal and double-sized **textures in folders** `…/assets/1x` and `…/assets/2x`, respectively;
3. **Rewrite the header** as desired;
4. **Edit the variables below the header** to match (filename as saved in the assets, prefix as defined in the header, etc.);
5. **Enjoy!**