### PR TITLE
Allow String keys in Localization Strings and Add default loc_vars function

### DIFF
--- a/lovely/localization.toml
+++ b/lovely/localization.toml
@@ -8,7 +8,7 @@ priority = 0
 target = 'functions/misc_functions.lua'
 pattern = '''args\.vars\[(?<index>.*)\]'''
 position = 'at'
-payload = '''args.vars[$index] or args.vars.extra[$index]'''
+payload = '''args.vars[$index] or (args.vars.extra and args.vars.extra[$index])'''
 line_prepend = ''
 
 [[patches]]

--- a/lovely/localization.toml
+++ b/lovely/localization.toml
@@ -3,6 +3,7 @@ version = "1.0.0"
 dump_lua = true
 priority = 0
 
+# Add compat for the config.extra field if the field doesn't exist in config
 [[patches]]
 [patches.regex]
 target = 'functions/misc_functions.lua'
@@ -11,6 +12,7 @@ position = 'at'
 payload = '''args.vars[$index] or (args.vars.extra and args.vars.extra[$index])'''
 line_prepend = ''
 
+# If key isn't a number just read then just use the key directly
 [[patches]]
 [patches.regex]
 target = 'functions/misc_functions.lua'

--- a/lovely/localization.toml
+++ b/lovely/localization.toml
@@ -1,0 +1,12 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.regex]
+target = 'functions/misc_functions.lua'
+pattern = '''tonumber\(subpart\[1\]\)'''
+position = 'at'
+payload = '''tonumber(subpart[1]) or subpart[1]'''
+line_prepend = ''

--- a/lovely/localization.toml
+++ b/lovely/localization.toml
@@ -6,6 +6,14 @@ priority = 0
 [[patches]]
 [patches.regex]
 target = 'functions/misc_functions.lua'
+pattern = '''args\.vars\[(?<index>.*)\]'''
+position = 'at'
+payload = '''args.vars[$index] or args.vars.extra[$index]'''
+line_prepend = ''
+
+[[patches]]
+[patches.regex]
+target = 'functions/misc_functions.lua'
 pattern = '''tonumber\(subpart\[1\]\)'''
 position = 'at'
 payload = '''tonumber(subpart[1]) or subpart[1]'''

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1159,6 +1159,9 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 desc_nodes[#desc_nodes + 1] = res.main_end
             end
             desc_nodes.background_colour = res.background_colour
+        end,
+        loc_vars = function(self, ...)
+            return {vars = (self.config or {})}
         end
     }
 
@@ -1236,9 +1239,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             SMODS.remove_pool(G.P_CENTER_POOLS['Consumeables'], self.key)
             SMODS.Consumable.super.delete(self)
         end,
-        loc_vars = function(self, info_queue)
-            return {}
-        end
     }
     
     SMODS.Tarot = SMODS.Consumable:extend {


### PR DESCRIPTION
Adds a default loc_vars function and allows for returned args from loc_vars to use not just number keys but also string keys. Alters the localization function directly so the string key change can be used in any text field as long as the args has that string key.

Example:
```lua
SMODS.Joker {
    key = 'pacifist',
    loc_txt = {
        name = 'Pacifist Joker',
        text = {"Played cards with", "{C:spades}#suit#{} suit give", "{C:chips}+#chips#{} Chips when scored"}
    },
    config = {
        chips = 50,
        suit = 'Spades'
    },
...
```

Would remove a lot of boilerplate and would probably mean most people would never have to interact with the loc_vars function

It also reads the `extra` table as a fallback if the key doesn't exist.