### PR TITLE
fix native Linux

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -635,24 +635,6 @@ payload = '''NFS.setWorkingDirectory(cwd)
 [[patches]]
 [patches.pattern]
 target = "main.lua"
-pattern = '''if os == 'OS X' or os == 'Windows' then'''
-position = "at"
-payload = '''if os == 'OS X' or os == 'Windows' or os == 'Linux' then'''
-overwrite = true
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "main.lua"
-pattern = '''if os == 'OS X' then'''
-position = "at"
-payload = '''if os == 'OS X' or os == 'Linux' then'''
-overwrite = true
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "main.lua"
 pattern = "st = require 'luasteam'"
 position = "at"
 payload = """local success, _st = pcall(require, 'luasteam')


### PR DESCRIPTION
Hi!
I am the maintainer of the package for balatro on NixOS! I tried to update to the latest version, but support with native Linux (no Wine) was broken by some 'fixes' in [lovely/fixes.toml](lovely/fixes.toml).

In native Linux installation, `luasteam` is not available and the proposed 'fix' crashes the game.
This patch reverts this specific 'fix', making Steamodded native Linux compatible.

When run without this patch (and without any other mod), Steammoded crashes with the following trace:
```
Oops! The game crashed:
main.lua:969: attempt to index local 'st' (a nil value)

Additional Context:
Balatro Version: 1.0.1n-FULL
Modded Version: 1.0.0~ALPHA-1230c-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.6.0
Steamodded Mods:
    1: Pokermon by InertSteak, Please See Credits Page [ID: Pokermon, Version: 2.1.0b, Uses Lovely]
Lovely Mods:

Stack Traceback
===============
(3) Lua field 'load' at file 'main.lua:969'
Local variables:
 os = string: "Linux"
 st = nil
 cwd = string: "/home/user/.local/share/Balatro"
 (*temporary) = table: 0x7f296c0b07b0  {last_sent_stage:-1, force:false, last_sent_time:-200}
 (*temporary) = string: "./?.so;/usr/local/lib/lua/5.1/?.so;/nix/store/1gspwvbz68wgb09ni4qaqzvi63izxplw-luajit-2.1.1713773202/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so"
 (*temporary) = boolean: false
 (*temporary) = string: "module 'luasteam' not found:\
\9no field package.preload['luasteam']\
\9no 'luasteam' in LOVE game directories.\
\9no file 'luasteam' in LOVE paths.\
\9no file './luasteam.lua'\
\9no file '/nix/store/1gspwvbz68wgb09ni4qaqzvi63izxplw-luajit-2.1.1713773202/share/luajit-2.1/luasteam.lua'\
\9no file '/usr/local/share/lua/5.1/luasteam.lua'\
\9no file '/usr/local/share/lua/5.1/luasteam/init.lua'\
\9no file '/nix/store/1gspwvbz68wgb09ni4qaqzvi63izxplw-luajit-2.1.1713773202/share/lua/5.1/luasteam.lua'\
\9no file '/nix/store/1gspwvbz68wgb09ni4qaqzvi63izxplw-luajit-2.1.1713773202/share/lua/5.1/luasteam/init.lua'\
\9no file './luasteam.so'\
\9no file '/usr/local/lib/lua/5.1/luasteam.so'\
\9no file '/nix/store/1gspwvbz68wgb09ni4qaqzvi63izxplw-luajit-2.1.1713773202/lib/lua/5.1/luasteam.so'\
\9no file '/usr/local/lib/lua/5.1/loadall.so'\
\9no file '/nix/store/0c1x7010vkv3srsb3n10qpzvjhanrhxh-balatro-1.0.1n/share/luasteam.so'"
 (*temporary) = package module
 (*temporary) = number: 1.08694e-322
 (*temporary) = string: "luasteam"
 (*temporary) = string: "attempt to index local 'st' (a nil value)"
(4) Lua function '?' at file 'main.lua:892' (best guess)
(5) global C function 'xpcall'
(6) LÖVE function at file 'boot.lua:368' (best guess)
Local variables:
 result = boolean: true
 main = nil
(7) global C function 'xpcall'
(8) LÖVE function at file 'boot.lua:377' (best guess)
Local variables:
 func = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])
 inerror = boolean: true
 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])
```

This patch fixes the problem on native Linux.